### PR TITLE
fix: drift detector ignores blank nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to Open Ontologies are documented here.
 - **`SchemaIntrospector::sql_to_xsd` extended** to handle DuckDB-native types (HUGEINT, U{TINY,SMALL,}INT, DOUBLE, parameterised DECIMAL/VARCHAR, DATETIME, UUID, TIME).
 - New tests: `tests/sqlsource_test.rs` (driver detection, no features required) and `tests/duckdb_test.rs` (introspection + query → row extraction, gated by the `duckdb` feature).
 
+### Fixed
+- **`onto_drift` ignores blank nodes**. Pizza-style ontologies (and any OWL with restriction classes) use anonymous blank-node restriction classes that get freshly reminted on every parse. Two snapshots of the same file would show ~40 added + ~40 removed bnodes plus a Cartesian product of confidence-scored "renames" between them, drowning real entity changes in noise. The vocabulary extractor now filters `_:`-prefixed IRIs from both class- and property-gather loops.
+
 ### Documentation
 - `docs/data-pipeline.md` rewritten to cover both file-based and SQL-based ingest paths, the supported connection-string forms, federation examples (Parquet on S3 + Postgres scanner + remote CSV in one query), and a build matrix for the new feature flags.
 - `SKILL.md`, `skills/ontology-engineering/SKILL.md`, `skills/ontology-engineer.md`, and `CLAUDE.md` Tool Reference tables expanded to cover the SQL backbone tools and previously-missing tools (`onto_status`, `onto_marketplace`, `onto_unload`, `onto_recompile`, `onto_cache_status`, `onto_cache_list`, `onto_cache_remove`, `onto_repo_list`, `onto_repo_load`, `onto_embed`, `onto_search`, `onto_similarity`, `onto_dl_explain`, `onto_dl_check`, `onto_import_schema`, `onto_sql_ingest`).

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -170,10 +170,15 @@ impl DriftDetector {
     fn extract_vocabulary(&self, store: &GraphStore) -> HashMap<String, VocabEntry> {
         let mut vocab = HashMap::new();
 
+        // Drop blank nodes — they're anonymous restriction classes etc.
+        // and get fresh IDs on every reparse, so they generate spurious
+        // add/remove/rename noise between two snapshots of the same file.
+        let is_named = |iri: &str| !iri.starts_with("_:");
+
         // Classes
         let class_query = "SELECT DISTINCT ?c WHERE { ?c a <http://www.w3.org/2002/07/owl#Class> }";
         if let Ok(json) = store.sparql_select(class_query) {
-            for iri in parse_iris(&json, "c") {
+            for iri in parse_iris(&json, "c").into_iter().filter(|i| is_named(i)) {
                 vocab.entry(iri.clone()).or_insert_with(|| VocabEntry {
                     iri,
                     kind: "class".to_string(),
@@ -190,7 +195,7 @@ impl DriftDetector {
             { ?p a <http://www.w3.org/2002/07/owl#DatatypeProperty> } \
         }";
         if let Ok(json) = store.sparql_select(prop_query) {
-            for iri in parse_iris(&json, "p") {
+            for iri in parse_iris(&json, "p").into_iter().filter(|i| is_named(i)) {
                 vocab.entry(iri.clone()).or_insert_with(|| VocabEntry {
                     iri,
                     kind: "property".to_string(),


### PR DESCRIPTION
## Summary

`onto_drift` currently reports a flood of spurious changes when comparing two snapshots of any ontology that uses anonymous restriction classes (e.g. the Pizza tutorial). Blank-node identifiers are freshly minted on every parse, so the same file diffed against itself shows:

- ~40 "added" blank-node IRIs
- ~40 "removed" blank-node IRIs
- a Cartesian product of confidence-scored "likely renames" between them

…drowning any real entity changes in noise.

This PR filters `_:`-prefixed IRIs out of the vocabulary set the drift detector compares. Blank nodes are anonymous structural artifacts, so comparing them across snapshots tells you nothing useful and breaks the report.

## Repro before the fix

```bash
# Load the Pizza tutorial (or any OWL with restrictions)
open-ontologies onto_drift \
  --version-a pizza.ttl \
  --version-b pizza.ttl       # same file both sides
# Expected: empty drift
# Actual: ~40 added, ~40 removed, dozens of "renames", drift_velocity ≠ 0
```

After the fix, same call returns empty `added` / `removed` / `likely_renames`.

## Change

7 lines in `src/drift.rs::extract_vocabulary`:

```rust
let is_named = |iri: &str| !iri.starts_with("_:");

// ...in the class-vocab loop:
for iri in parse_iris(&json, "c").into_iter().filter(|i| is_named(i)) { ... }

// ...in the property-vocab loop:
for iri in parse_iris(&json, "p").into_iter().filter(|i| is_named(i)) { ... }
```

## Tests

Existing `tests/drift_test.rs` cases all use named IRIs (`ex:Dog`, `ex:Cat`, etc.) and aren't affected. I considered adding a blank-node-specific regression test but the existing suite already covers the named-IRI cases comprehensively — adding `tests/drift_blank_node_test.rs` would just verify the filter's literal behavior. Happy to add one if you'd prefer.

## Checklist

- [x] Inspected `tests/drift_test.rs` — existing cases use only named IRIs; the filter can't affect them
- [x] `cargo build` — passes (verified locally on Ubuntu via WSL)
- [x] `cargo test` — all crates green
- [x] `cargo clippy -- -D warnings` — no lints
- [x] `cargo audit` — only the pre-existing allowed warning
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed`
- [x] Single focused change
