### PR TITLE
docs(readme): resolve merge conflict in Tools table + fix stale tool count

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,20 +699,12 @@ The same tool, applied to any ontology, produces the same kind of improvement. T
 | **Planner** | `plan_compile_pddl` `plan_classical` `plan_validate` | Compile + validate on the server; solver (Fast Downward) is a client-side subprocess |
 | **Governance** | `policy_register` `policy_list` `policy_check` | Authorisation rules; composes with `certify_action` |
 | **RAG** | `segment_retrieve` `graph_projection_lossy_check` | TBox-slice retrieval + projection-loss auditor |
-<<<<<<< HEAD
-| **Extraction (#28)** | `extract_scaffold` `extract_validate` | Schema-guided structured-extraction prompt + validator (MCP-native SPIRES) |
-| **CQs** | `cq_run` `verify_cq` `cq_verdicts_list` | Competency-question runner with VSPO pitfall hints + LLM-judgement loop |
-| **Shape induction** | `shape_combinatorics` | Property-combination lattice for SHACL-shape induction |
-| **Borderline loop** | `borderline_partition` `borderline_record_verdict` | Generalised two-threshold borderline pattern for any candidate set |
-| **Evaluation** | `eval_alignment` `eval_rag` | Alignment P/R/F1 + RAG Hit@k / MRR scoring |
-=======
 | **Extraction** | `extract_scaffold` `extract_validate` | Schema-guided structured-extraction prompt + validator |
 | **CQs** | `cq_run` `verify_cq` `cq_verdicts_list` | Competency-question runner with pitfall hints + judgement loop |
 | **Shape induction** | `shape_combinatorics` `shape_induce` | Property-combination lattice + data-driven SHACL induction |
 | **Borderline loop** | `borderline_partition` `borderline_record_verdict` | Generalised two-threshold review pattern for any candidate set |
 | **SQL sync** | `sql_sync_state` `sql_sync_reset` `sql_sync_states_list` | CDC watermark tracking for incremental SQL ingest |
 | **Evaluation** | `eval_alignment` `eval_rag` `eval_rag_mmrag` | Alignment P/R/F1 + RAG Hit@k / MRR / faithfulness + dataset adapter |
->>>>>>> 6dfac63 (docs(readme): strip paper-attribution framing; describe what the tools do, not where they came from)
 
 ---
 
@@ -736,7 +728,7 @@ flowchart TD
             REST["REST API\n/api/query · /api/update\n/api/save · /api/load · /api/lineage"]
         end
 
-        subgraph ToolGroups["43 Tools"]
+        subgraph ToolGroups["70+ Tools"]
             direction LR
             Core["Core\nvalidate · load · save · clear\nstats · query · diff · lint\nconvert · status"]
             DataPipe["Data Pipeline\nmap · ingest · shacl\nreason · extend · import-schema"]


### PR DESCRIPTION
## Problem

The README on `main` has two issues visible to anyone reading it on GitHub:

1. **Unresolved git conflict markers** committed into the Tools table (`<<<<<<< HEAD` / `=======` / `>>>>>>> 6dfac63`), left over from the `6dfac63` merge.
2. The architecture-diagram label still says **`43 Tools`**, while the headline and Tools section already say **70+ tools**.

## Fix

- **Resolve the conflict** in favour of the `6dfac63` side. That commit's purpose was to strip paper-attribution framing (`(#28)`, `MCP-native SPIRES`, `VSPO`), and its side also carries the fuller list (`shape_induce`, a `SQL sync` category, `eval_rag_mmrag`). The `HEAD` side is dropped.
- **Update the diagram label** `43 Tools` → `70+ Tools` for internal consistency. Counting the resolved table yields ~90 tool entries, so 70+ is accurate.

Doc-only change; 1 insertion / 9 deletions.