### PR TITLE
SPARQL auth bridge (Stardog/GraphDB) + citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+cff-version: 1.2.0
+message: "If you use Open Ontologies in your research, please cite the paper below."
+title: "Open Ontologies"
+abstract: >-
+  An AI-native ontology engine: a Rust MCP server with tools for building,
+  validating, querying, reasoning over, aligning, planning, and governing
+  RDF/OWL ontologies, backed by an in-memory Oxigraph triple store and a
+  three-layer Dynamics to Causal to Planner architecture.
+type: software
+authors:
+  - family-names: Rovai
+    given-names: Fabio
+repository-code: "https://github.com/fabio-rovai/open-ontologies"
+license: MIT
+keywords:
+  - knowledge-graph
+  - ontology
+  - rdf
+  - owl
+  - sparql
+  - shacl
+  - mcp
+  - model-context-protocol
+  - ontology-alignment
+  - causal-inference
+
+# Cite this paper when referencing the system.
+preferred-citation:
+  type: article
+  title: "Open Ontologies: Tool-Augmented Ontology Engineering with Stable Matching Alignment"
+  authors:
+    - family-names: Rovai
+      given-names: Fabio
+  year: 2026
+  month: 5
+  identifiers:
+    - type: other
+      value: "arXiv:2605.09184"
+      description: arXiv preprint
+  doi: 10.48550/arXiv.2605.09184
+  url: "https://arxiv.org/abs/2605.09184"
+
+# Further reading: the causal-verification foundation of the Causal layer.
+references:
+  - type: article
+    title: "CIVeX: Causal Intervention Verification for Language Agents"
+    authors:
+      - family-names: Rovai
+        given-names: Fabio
+    year: 2026
+    month: 5
+    identifiers:
+      - type: other
+        value: "arXiv:2605.09168"
+        description: arXiv preprint
+    doi: 10.48550/arXiv.2605.09168
+    url: "https://arxiv.org/abs/2605.09168"

--- a/README.md
+++ b/README.md
@@ -870,6 +870,30 @@ flowchart TD
 
 ---
 
+## Citation
+
+Open Ontologies is described in a preprint. The alignment engine implements the
+stable-matching method introduced there; the Causal layer builds on the
+intervention-verification framework of CIVeX.
+
+- **Open Ontologies: Tool-Augmented Ontology Engineering with Stable Matching Alignment.** Fabio Rovai, 2026. [arXiv:2605.09184](https://arxiv.org/abs/2605.09184)
+- **CIVeX: Causal Intervention Verification for Language Agents.** Fabio Rovai, 2026. [arXiv:2605.09168](https://arxiv.org/abs/2605.09168)
+
+```bibtex
+@article{rovai2026openontologies,
+  title   = {Open Ontologies: Tool-Augmented Ontology Engineering with Stable Matching Alignment},
+  author  = {Rovai, Fabio},
+  journal = {arXiv preprint arXiv:2605.09184},
+  year    = {2026},
+  doi     = {10.48550/arXiv.2605.09184},
+  url     = {https://arxiv.org/abs/2605.09184}
+}
+```
+
+See [`CITATION.cff`](CITATION.cff) for machine-readable metadata. It powers GitHub's "Cite this repository" button.
+
+---
+
 ## License
 
 MIT

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,6 +6,48 @@ use oxigraph::model::*;
 use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
 
+/// Optional HTTP authentication for remote SPARQL endpoints.
+///
+/// Enterprise triple stores gate their SPARQL Protocol endpoints behind auth:
+/// Stardog and Ontotext GraphDB accept HTTP Basic; token-secured deployments
+/// accept a Bearer token. Open stores (Apache Jena/Fuseki, Eclipse RDF4J,
+/// public Virtuoso) need none — leave this empty.
+#[derive(Default, Clone)]
+pub struct SparqlAuth {
+    /// HTTP Basic credentials as (username, password).
+    pub basic: Option<(String, String)>,
+    /// Bearer token (takes precedence over `basic` if both are set).
+    pub bearer: Option<String>,
+}
+
+impl SparqlAuth {
+    /// Build from optional username/password/token (e.g. tool inputs).
+    /// Returns a no-auth value when all are absent.
+    pub fn from_parts(
+        username: Option<String>,
+        password: Option<String>,
+        token: Option<String>,
+    ) -> Self {
+        let basic = match (username, password) {
+            (Some(u), Some(p)) => Some((u, p)),
+            (Some(u), None) => Some((u, String::new())),
+            _ => None,
+        };
+        SparqlAuth { basic, bearer: token }
+    }
+
+    /// Apply the configured auth to a request builder.
+    fn apply(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(t) = &self.bearer {
+            rb.bearer_auth(t)
+        } else if let Some((u, p)) = &self.basic {
+            rb.basic_auth(u, Some(p))
+        } else {
+            rb
+        }
+    }
+}
+
 /// In-memory RDF graph store backed by Oxigraph.
 pub struct GraphStore {
     store: Mutex<Store>,
@@ -319,29 +361,59 @@ impl GraphStore {
         Ok(resp.text().await?)
     }
 
+    /// Run a SPARQL query against an open (unauthenticated) endpoint.
     pub async fn fetch_sparql(endpoint: &str, query: &str) -> anyhow::Result<String> {
+        Self::fetch_sparql_auth(endpoint, query, &SparqlAuth::default()).await
+    }
+
+    /// Run a SPARQL query against an endpoint, with optional HTTP auth.
+    ///
+    /// Works against any SPARQL 1.1 Protocol endpoint: Apache Jena/Fuseki and
+    /// Eclipse RDF4J (no auth), Stardog and Ontotext GraphDB (Basic/Bearer).
+    /// Amazon Neptune with IAM auth requires SigV4 request signing, which this
+    /// path does not perform; use an unsigned/IAM-disabled endpoint or a signing
+    /// proxy in front of Neptune.
+    pub async fn fetch_sparql_auth(
+        endpoint: &str,
+        query: &str,
+        auth: &SparqlAuth,
+    ) -> anyhow::Result<String> {
         let client = reqwest::Client::new();
-        let resp = client
+        let rb = client
             .post(endpoint)
             .header("Content-Type", "application/sparql-query")
             .header("Accept", "text/turtle")
-            .body(query.to_string())
-            .send()
-            .await?;
+            .body(query.to_string());
+        let resp = auth.apply(rb).send().await?;
         if !resp.status().is_success() {
             anyhow::bail!("SPARQL endpoint returned HTTP {}", resp.status());
         }
         Ok(resp.text().await?)
     }
 
+    /// Push triples to an open (unauthenticated) endpoint, default graph.
     pub async fn push_sparql(endpoint: &str, content: &str) -> anyhow::Result<String> {
+        Self::push_sparql_auth(endpoint, content, None, &SparqlAuth::default()).await
+    }
+
+    /// Push triples to an endpoint via SPARQL 1.1 Update, with optional named
+    /// graph and HTTP auth.
+    pub async fn push_sparql_auth(
+        endpoint: &str,
+        content: &str,
+        graph: Option<&str>,
+        auth: &SparqlAuth,
+    ) -> anyhow::Result<String> {
+        let update = match graph {
+            Some(g) => format!("INSERT DATA {{ GRAPH <{g}> {{ {content} }} }}"),
+            None => format!("INSERT DATA {{ {content} }}"),
+        };
         let client = reqwest::Client::new();
-        let resp = client
+        let rb = client
             .post(endpoint)
             .header("Content-Type", "application/sparql-update")
-            .body(format!("INSERT DATA {{ {} }}", content))
-            .send()
-            .await?;
+            .body(update);
+        let resp = auth.apply(rb).send().await?;
         if !resp.status().is_success() {
             anyhow::bail!("SPARQL update returned HTTP {}", resp.status());
         }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -147,6 +147,12 @@ pub struct OntoPullInput {
     pub sparql: Option<bool>,
     /// Optional SPARQL CONSTRUCT query (required if sparql=true)
     pub query: Option<String>,
+    /// HTTP Basic username for authenticated endpoints (Stardog, GraphDB)
+    pub username: Option<String>,
+    /// HTTP Basic password for authenticated endpoints
+    pub password: Option<String>,
+    /// Bearer token for token-secured endpoints (overrides username/password)
+    pub token: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -155,6 +161,12 @@ pub struct OntoPushInput {
     pub endpoint: String,
     /// Optional named graph IRI
     pub graph: Option<String>,
+    /// HTTP Basic username for authenticated endpoints (Stardog, GraphDB)
+    pub username: Option<String>,
+    /// HTTP Basic password for authenticated endpoints
+    pub password: Option<String>,
+    /// Bearer token for token-secured endpoints (overrides username/password)
+    pub token: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -558,10 +558,11 @@ impl OpenOntologiesServer {
 
     #[tool(name = "onto_pull", description = "Fetch an ontology from a remote URL or SPARQL endpoint and load it into the store")]
     async fn onto_pull(&self, Parameters(input): Parameters<OntoPullInput>) -> String {
-        use crate::graph::GraphStore;
+        use crate::graph::{GraphStore, SparqlAuth};
+        let auth = SparqlAuth::from_parts(input.username, input.password, input.token);
         if input.sparql.unwrap_or(false) {
             let query = input.query.as_deref().unwrap_or("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
-            match GraphStore::fetch_sparql(&input.url, query).await {
+            match GraphStore::fetch_sparql_auth(&input.url, query, &auth).await {
                 Ok(content) => {
                     match self.graph.load_turtle(&content, None) {
                         Ok(count) => format!(r#"{{"ok":true,"triples_loaded":{},"source":"{}"}}"#, count, input.url),
@@ -585,10 +586,11 @@ impl OpenOntologiesServer {
 
     #[tool(name = "onto_push", description = "Push the current ontology store to a remote SPARQL endpoint")]
     async fn onto_push(&self, Parameters(input): Parameters<OntoPushInput>) -> String {
-        use crate::graph::GraphStore;
+        use crate::graph::{GraphStore, SparqlAuth};
+        let auth = SparqlAuth::from_parts(input.username, input.password, input.token);
         match self.graph.serialize("ntriples") {
             Ok(content) => {
-                match GraphStore::push_sparql(&input.endpoint, &content).await {
+                match GraphStore::push_sparql_auth(&input.endpoint, &content, input.graph.as_deref(), &auth).await {
                     Ok(msg) => format!(r#"{{"ok":true,"message":"{}"}}"#, msg),
                     Err(e) => format!(r#"{{"error":"{}"}}"#, e),
                 }


### PR DESCRIPTION
## Summary
- **SPARQL auth bridge:** `onto_pull`/`onto_push` now accept `username`/`password` (HTTP Basic) and `token` (Bearer), unlocking authenticated SPARQL 1.1 endpoints (Stardog, Ontotext GraphDB). Open endpoints (Jena/Fuseki, RDF4J) still work with no credentials.
- `push_sparql_auth` now honours the named-graph parameter (`INSERT DATA { GRAPH <g> { ... } }`), previously ignored.
- Existing `fetch_sparql`/`push_sparql` kept as no-auth wrappers, so `batch.rs`/`main.rs` callers are untouched.
- **Citation:** add `CITATION.cff` (GitHub "Cite this repository") + README Citation section referencing arXiv:2605.09184 and arXiv:2605.09168.

## Not covered
Amazon Neptune with IAM auth requires SigV4 request signing (not implemented). Use a signing proxy or an IAM-disabled endpoint.

## Verification
`cargo check` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)