### PR TITLE
ci(release): populate GitHub release body from CHANGELOG.md on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - name: Rename binaries
         run: |
@@ -56,7 +57,15 @@ jobs:
               mv "${dir}open-ontologies" "${dir}open-ontologies-${target}"
             fi
           done
+      - name: Extract release notes from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if ! bash scripts/extract-changelog.sh "$version" > release-notes.md; then
+            echo "::warning::No CHANGELOG section found for ${version}; publishing with an empty body"
+            : > release-notes.md
+          fi
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          body_path: release-notes.md
           files: open-ontologies-*/open-ontologies-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,17 @@ The codebase is organized into domain modules under `src/`:
 - Update CHANGELOG.md for user-facing changes
 - CI must pass (build, test, clippy, audit)
 
+## Releasing
+
+Releases are cut from tags and their GitHub release notes are populated automatically from CHANGELOG.md. The convention:
+
+1. Add the CHANGELOG.md entry for the new version first. Both heading formats in use are recognized by the automation: `## X.Y.Z - YYYY-MM-DD` (bare version) and `## [X.Y.Z] - YYYY-MM-DD` (bracketed version).
+2. Bump `version` in `Cargo.toml` to the same `X.Y.Z` and commit both changes together.
+3. Tag that commit: `git tag vX.Y.Z` (the tag carries the leading `v`; the CHANGELOG heading does not need one).
+4. Push the tag: `git push origin vX.Y.Z`.
+
+Pushing the tag fires `.github/workflows/release.yml`, which builds the binaries, extracts the matching CHANGELOG section via `scripts/extract-changelog.sh`, and publishes the release with that section as the body. If no matching section exists, the release still publishes with an empty body, so check the heading version matches the tag before pushing.
+
 ## Code Style
 
 - Follow standard Rust conventions (rustfmt defaults)

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# extract-changelog.sh <version>
+#
+# Prints the CHANGELOG.md section body for the given version to stdout,
+# excluding the heading line itself. Handles the mixed heading formats
+# used in this repo:
+#
+#   ## 1.1.1 <em dash> 2026-08-03   (bare version, em dash separator)
+#   ## [0.1.13] - 2026-05-01   (bracketed version, ASCII hyphen)
+#   ## [Unreleased]
+#
+# The section ends at the next line starting with "## " or at EOF.
+# Leading and trailing blank lines are stripped. A leading "v" on the
+# argument is accepted ("v1.1.0" == "1.1.0"). Exits non-zero with a
+# message on stderr when the version is not found.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+
+version="${1#v}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+changelog="${script_dir}/../CHANGELOG.md"
+
+if [ ! -f "$changelog" ]; then
+  echo "error: CHANGELOG.md not found at $changelog" >&2
+  exit 1
+fi
+
+awk -v version="$version" '
+  /^## / {
+    if (printing) exit 0
+    heading = $0
+    sub(/^## /, "", heading)
+    gsub(/[\[\]]/, "", heading)
+    split(heading, parts, /[ \t]+/)
+    if (parts[1] == version) { found = 1; printing = 1 }
+    next
+  }
+  printing { lines[++n] = $0 }
+  END {
+    if (!found) exit 1
+    first = 1
+    while (first <= n && lines[first] ~ /^[[:space:]]*$/) first++
+    last = n
+    while (last >= first && lines[last] ~ /^[[:space:]]*$/) last--
+    for (i = first; i <= last; i++) print lines[i]
+  }
+' "$changelog" || {
+  echo "error: version '$1' not found in CHANGELOG.md" >&2
+  exit 1
+}


### PR DESCRIPTION
Follow-up to #66.

Cutting v1.1.0 and v1.1.1 exposed a second half of that issue: the release job passed only `files:` to `softprops/action-gh-release@v2`, so both releases published with completely empty bodies. Tagging fixed the version numbers while leaving anyone reading the Releases page no better informed about what changed. The bodies for v1.1.0 and v1.1.1 were populated by hand; this makes it automatic.

## Changes

- `scripts/extract-changelog.sh`: prints a given version's CHANGELOG section body. Handles both heading formats in use (`## 1.1.1 — 2026-08-03` and `## [0.1.13] - 2026-05-01`), accepts an optional leading `v`, trims blank lines, exits non-zero when the version is absent.
- `.github/workflows/release.yml`: adds `actions/checkout@v4` (the release job had no source checkout, only `download-artifact`), extracts notes for the pushed tag, and passes them via `body_path:`. Extraction failure warns and falls back to an empty body rather than failing the release, so a mismatched tag degrades to current behaviour instead of losing the binaries.
- `CONTRIBUTING.md`: documents the convention. CHANGELOG entry first, tag `vX.Y.Z` on the Cargo.toml version-bump commit, push the tag.

## Verification

- `1.1.1`, `1.1.0`, `v1.1.0`, `0.1.13` all extract correctly; `v`-prefixed and bare forms are byte-identical.
- `9.9.9` exits 1 with a stderr message.
- Output for 1.1.1 matches the body currently live on the v1.1.1 release, modulo leading and trailing blank lines which the script strips.
- `release.yml` validated as YAML; `files:` and the rename logic are unchanged.