### PR TITLE
ci(audit): exempt RUSTSEC-2026-0235 (rkyv), not compiled in any configuration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,4 +11,17 @@ ignore = [
     # the next oxigraph release.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # rkyv 0.7.46 out-of-bounds reads on archives containing Rc/Arc.
+    # Not compiled by this project in any configuration. rkyv is an OPTIONAL
+    # dependency of rust_decimal (rust_decimal-1.42.1/Cargo.toml: `rkyv =
+    # ["dep:rkyv"]`), reaching us only via duckdb -> rust_decimal, and duckdb
+    # does not enable that feature. Verified: `cargo tree --all-features
+    # --target all -i rkyv` returns no results, while `-i rust_decimal` shows
+    # rust_decimal -> duckdb -> open-ontologies. cargo audit reads Cargo.lock,
+    # which records optional dependencies the compiler never sees.
+    # Unfixable by version bump: the advisory requires >= 0.8.17, but
+    # rust_decimal pins rkyv 0.7.46 exactly and has not migrated to the 0.8
+    # line (it carries a separate rkyv-0_8 dev-dependency). Remove this entry
+    # once rust_decimal ships a release depending on rkyv 0.8.
+    "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
CI is currently red on `main` and on every open PR. The cause is a new advisory rather than any code change: RUSTSEC-2026-0235, `rkyv` 0.7.46, out-of-bounds reads on archives containing `Rc`/`Arc`.

The vulnerable code is never compiled by this project.

- `rkyv` is an **optional** dependency of `rust_decimal` (`rust_decimal-1.42.1/Cargo.toml`: `rkyv = ["dep:rkyv"]`).
- It reaches us only through `duckdb` -> `rust_decimal`, and `duckdb` does not enable that feature.
- `cargo tree --all-features --target all -i rkyv` returns **no results**, while `-i rust_decimal` shows `rust_decimal -> duckdb -> open-ontologies`.

`cargo audit` reads `Cargo.lock`, which records the union of optional dependencies regardless of whether any feature selection can reach them, so it flags crates the compiler never sees.

There is also no in-range fix. The advisory requires `>= 0.8.17`; `rust_decimal` pins `rkyv 0.7.46` exactly and has not migrated to the 0.8 line (it currently carries a separate `rkyv-0_8` dev-dependency). `cargo update` cannot resolve this.

The exemption is recorded in `.cargo/audit.toml` in the same style as the existing entries, with the evidence and a removal condition: drop it once `rust_decimal` ships a release depending on rkyv 0.8.

Raised separately from #71 so the reasoning is reviewable on its own rather than bundled into an unrelated change.