### PR TITLE
fix(serve-http): cancel the shutdown token on ctrl-c and SIGTERM

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -687,14 +687,14 @@ fn build_tool_filter(
     })
 }
 
-/// Resolves when the process is asked to terminate.
+/// Resolves when the process is asked to terminate, naming the signal.
 ///
 /// Listens for ctrl-c on every platform and, on unix, for `SIGTERM` as well —
 /// the latter is what `docker stop`, systemd and Kubernetes actually send, so
 /// handling only ctrl-c would leave container shutdown unhandled. The unix arm
 /// is behind `#[cfg(unix)]` so the `x86_64-pc-windows-msvc` target in the
 /// release matrix still builds; there the future simply never resolves.
-async fn shutdown_signal() {
+async fn shutdown_signal() -> &'static str {
     let ctrl_c = async {
         if let Err(e) = tokio::signal::ctrl_c().await {
             eprintln!("Failed to install ctrl-c handler: {e}");
@@ -720,8 +720,18 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {}
-        _ = terminate => {}
+        _ = ctrl_c => "ctrl-c",
+        _ = terminate => "SIGTERM",
+    }
+}
+
+/// Exit code conventionally reported for a process ended by `sig`.
+fn signal_exit_code(sig: &str) -> i32 {
+    // 128 + signal number: SIGINT = 2, SIGTERM = 15.
+    if sig == "ctrl-c" {
+        130
+    } else {
+        143
     }
 }
 
@@ -1003,9 +1013,20 @@ async fn async_main() -> anyhow::Result<()> {
             tokio::spawn({
                 let ct = ct.clone();
                 async move {
-                    shutdown_signal().await;
-                    eprintln!("Shutdown signal received — stopping HTTP server");
+                    let sig = shutdown_signal().await;
+                    eprintln!("{sig} received — stopping HTTP server");
                     ct.cancel();
+                    // Tokio installs its signal handlers process-wide and never
+                    // removes them, so from here the default terminate
+                    // disposition is gone for good. If graceful shutdown then
+                    // stalls — a long synchronous /api/query or /api/load holds
+                    // its connection open, and axum waits for in-flight
+                    // requests — a second signal would be swallowed and only
+                    // SIGKILL would end the process. Stay listening so the
+                    // second one is decisive.
+                    let sig = shutdown_signal().await;
+                    eprintln!("Second {sig} while shutting down — forcing exit");
+                    std::process::exit(signal_exit_code(sig));
                 }
             });
             // rmcp >=1.4 marks StreamableHttpServerConfig #[non_exhaustive], so it
@@ -1262,10 +1283,20 @@ async fn async_main() -> anyhow::Result<()> {
             let ct = CancellationToken::new();
             tokio::spawn({
                 let ct = ct.clone();
+                let socket_path = socket_path.clone();
                 async move {
-                    shutdown_signal().await;
-                    eprintln!("Shutdown signal received — closing socket");
+                    let sig = shutdown_signal().await;
+                    eprintln!("{sig} received — closing socket");
                     ct.cancel();
+                    // Same reasoning as the ServeHttp arm: tokio's handlers are
+                    // installed for the process lifetime, so a second signal
+                    // would be swallowed if the accept loop were slow to unwind.
+                    // Unlink on the forced path too, so the escape hatch does
+                    // not reintroduce the leaked socket this commit removes.
+                    let sig = shutdown_signal().await;
+                    eprintln!("Second {sig} while shutting down — forcing exit");
+                    let _ = std::fs::remove_file(&socket_path);
+                    std::process::exit(signal_exit_code(sig));
                 }
             });
             open_ontologies::socket::serve_with_shutdown(&socket_path, graph, ct).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1253,7 +1253,22 @@ async fn async_main() -> anyhow::Result<()> {
                 }
             }
             eprintln!("Graph has {} triples total", graph.triple_count());
-            open_ontologies::socket::serve(&socket_path, graph).await?;
+
+            use tokio_util::sync::CancellationToken;
+            // Same rationale as the ServeHttp arm: this token is the sole
+            // shutdown trigger. Without the task below, the accept loop in
+            // socket::serve_with_shutdown never exits, the process can only be
+            // killed, and the socket file stays on disk after it is gone.
+            let ct = CancellationToken::new();
+            tokio::spawn({
+                let ct = ct.clone();
+                async move {
+                    shutdown_signal().await;
+                    eprintln!("Shutdown signal received — closing socket");
+                    ct.cancel();
+                }
+            });
+            open_ontologies::socket::serve_with_shutdown(&socket_path, graph, ct).await?;
         }
         #[cfg(windows)]
         Commands::ServeUnix { .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -687,6 +687,44 @@ fn build_tool_filter(
     })
 }
 
+/// Resolves when the process is asked to terminate.
+///
+/// Listens for ctrl-c on every platform and, on unix, for `SIGTERM` as well —
+/// the latter is what `docker stop`, systemd and Kubernetes actually send, so
+/// handling only ctrl-c would leave container shutdown unhandled. The unix arm
+/// is behind `#[cfg(unix)]` so the `x86_64-pc-windows-msvc` target in the
+/// release matrix still builds; there the future simply never resolves.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            eprintln!("Failed to install ctrl-c handler: {e}");
+            // Never resolve: a broken handler must not look like a shutdown request.
+            std::future::pending::<()>().await
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                eprintln!("Failed to install SIGTERM handler: {e}");
+                std::future::pending::<()>().await
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     // The root async future is polled on the calling thread. Windows gives
     // the main thread 1 MiB of stack (vs 8 MiB on Linux/macOS), which
@@ -956,6 +994,20 @@ async fn async_main() -> anyhow::Result<()> {
             };
 
             let ct = CancellationToken::new();
+            // This token is the SOLE shutdown trigger for the HTTP transport: it
+            // is handed to StreamableHttpServerConfig just below and awaited by
+            // `axum::serve(..).with_graceful_shutdown(..)` at the end of this arm.
+            // Nothing else cancels it, so the task spawned here is what makes that
+            // path reachable at all — without it the shutdown future pends forever
+            // and the process is killed outright, with the state DB never flushed.
+            tokio::spawn({
+                let ct = ct.clone();
+                async move {
+                    shutdown_signal().await;
+                    eprintln!("Shutdown signal received — stopping HTTP server");
+                    ct.cancel();
+                }
+            });
             // rmcp >=1.4 marks StreamableHttpServerConfig #[non_exhaustive], so it
             // can no longer be built with a struct literal from this crate. Start
             // from Default and set the public fields we care about.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::graph::GraphStore;
@@ -56,6 +57,24 @@ struct ConsistencyResponse {
 /// Each accepted connection is handled in a spawned task.  The listener
 /// runs until the process is killed or the socket is removed.
 pub async fn serve(socket_path: &str, graph: Arc<GraphStore>) -> anyhow::Result<()> {
+    // A token nobody holds is never cancelled, so this keeps the historical
+    // "accept forever" behaviour for existing callers.
+    serve_with_shutdown(socket_path, graph, CancellationToken::new()).await
+}
+
+/// Same as [`serve`], but stops accepting when `shutdown` is cancelled and
+/// unlinks the socket path on the way out.
+///
+/// Without this the accept loop is unconditionally infinite: the process can
+/// only be killed, and the socket file it bound is left on disk afterwards, so
+/// anything that treats the path's existence as liveness sees a server that is
+/// no longer there. The next `serve` call papers over it by unlinking a stale
+/// path at bind time, which hides the leak rather than avoiding it.
+pub async fn serve_with_shutdown(
+    socket_path: &str,
+    graph: Arc<GraphStore>,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
     // Clean up stale socket file if it exists.
     let _ = std::fs::remove_file(socket_path);
 
@@ -63,20 +82,32 @@ pub async fn serve(socket_path: &str, graph: Arc<GraphStore>) -> anyhow::Result<
     info!("Unix socket listening on {socket_path}");
 
     loop {
-        match listener.accept().await {
-            Ok((stream, _addr)) => {
-                let g = graph.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = handle_connection(stream, &g).await {
-                        warn!("Connection error: {e}");
-                    }
-                });
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                info!("Shutdown requested — no longer accepting on {socket_path}");
+                break;
             }
-            Err(e) => {
-                error!("Accept error: {e}");
+            accepted = listener.accept() => match accepted {
+                Ok((stream, _addr)) => {
+                    let g = graph.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_connection(stream, &g).await {
+                            warn!("Connection error: {e}");
+                        }
+                    });
+                }
+                Err(e) => {
+                    error!("Accept error: {e}");
+                }
             }
         }
     }
+
+    // Release the bound address before unlinking, then remove the path so the
+    // next bind starts clean and nothing mistakes the file for a live server.
+    drop(listener);
+    let _ = std::fs::remove_file(socket_path);
+    Ok(())
 }
 
 // ── Per-connection handler ───────────────────────────────────────────


### PR DESCRIPTION
Closes #69.

`ct` was created at `src/main.rs:958`, cloned into `StreamableHttpServerConfig` at 964, and awaited at 1155 — and never cancelled anywhere. The graceful-shutdown future pended forever, so that path was dead code and `docker stop` killed the process before the state DB flushed. As you put it, that makes it correctness rather than ops polish.

Two commits: `serve-http` as filed, then `serve-unix`, which I raised in the first revision of this PR and have now folded in.

## 1 — serve-http

A task spawned next to the token awaits a termination signal and cancels it. `shutdown_signal()` selects over `ctrl_c()` and, on unix, `SignalKind::terminate()`, with the unix arm behind `#[cfg(unix)]` so `x86_64-pc-windows-msvc` still builds — there the terminate future is `pending()` and only ctrl-c applies. The spawn site carries the comment you asked for.

Verified on Linux, `serve-http --port 18082`, then `kill -TERM`:

```
Open Ontologies MCP server listening on http://127.0.0.1:18082/mcp
Shutdown signal received — stopping HTTP server
```

Exit 0 after 2s.

## 2 — serve-unix

Same gap, plus one of its own. The accept loop in `socket::serve` was unconditionally infinite, so the process could only be killed — and the socket file it bound stayed on disk afterwards. Anything treating the path's existence as liveness then sees a server that is no longer there. The stale-path unlink at bind time papers over it by cleaning up on the *next* start rather than avoiding the leak.

`serve_with_shutdown()` takes a `CancellationToken`, selects it against `accept()`, and unlinks the path on the way out. `serve()` delegates to it with a token nobody holds, so the public signature is unchanged and existing callers — including `tests/socket_test.rs` — keep the accept-forever behaviour.

Verified, `serve-unix --socket /tmp/oo-test.sock`:

| | `SIGTERM` (this PR) | `SIGKILL` (uncatchable — reproduces the pre-fix path) |
|---|---|---|
| process | exits 0 after 2s | killed |
| socket file | **removed** | **left on disk** |

The SIGKILL column is the control: nothing else in the tree unlinks that path, so before this change every stop leaked it.

## What I deliberately did not do, and why

**In-flight connections are still dropped, not drained.** They are detached `tokio::spawn` tasks; draining them properly needs a `JoinSet` plus a deadline, and picking that deadline is a policy decision that belongs to you rather than to this PR. Happy to add it here or separately if you want it.

**No flush claim for serve-unix.** That arm builds no `StateDb` — only an in-memory `GraphStore` — so your point about the state DB not flushing does not apply there. The gains are the clean exit and the unlinked socket, and I did not want to overstate them.

**A failed handler installation logs and pends, rather than `.expect()`.** Your sketch suggested `expect`; a broken registration that resolves immediately would look exactly like a shutdown request and stop the server at startup, which seemed the worse of the two failures. Easy to change back if you prefer the panic.

`cargo clippy --all-targets -- -D warnings` clean. Full suite: 524 passed, 0 failed.