### PR TITLE
feat(serve-http): add an unauthenticated /health liveness route

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,16 @@ open-ontologies serve-http --host 127.0.0.1 --port 8080
 | Route | Auth | Purpose |
 |---|---|---|
 | `/mcp` | bearer, if a token is configured | MCP Streamable HTTP — the `onto_*` tools |
-| `/api/*` | bearer, if a token is configured | stats, events and other introspection |
+| `/api/stats`, `/api/lineage` | bearer, if a token is configured | read-only introspection |
+| `/api/query` | bearer, if a token is configured | SPARQL SELECT |
+| `/api/update`, `/api/load`, `/api/load-turtle`, `/api/save` | bearer, if a token is configured | **mutating** — SPARQL UPDATE, and `/load` / `/save` read and write files on the server at a path taken from the request body |
 | `/health` | never | liveness probe |
+
+> **The HTTP surface is not read-only.** When no token is configured the bearer
+> layer is not installed at all, so every route above — including the ones that
+> write to the server's filesystem — is reachable by anyone who can open the
+> port. Set a token, or bind to a loopback address, whenever the port is
+> reachable by anything other than the local process.
 
 `/health` returns `{"status":"ok","version":"<crate version>"}` and is
 deliberately outside the bearer layer, so an orchestrator can probe the process

--- a/README.md
+++ b/README.md
@@ -191,6 +191,28 @@ Add to `.cursor/mcp.json` or equivalent:
 
 </details>
 
+<details>
+<summary><strong>HTTP transport (<code>serve-http</code>)</strong></summary>
+
+For clients that speak MCP over HTTP rather than stdio:
+
+```bash
+open-ontologies serve-http --host 127.0.0.1 --port 8080
+```
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `/mcp` | bearer, if a token is configured | MCP Streamable HTTP — the `onto_*` tools |
+| `/api/*` | bearer, if a token is configured | stats, events and other introspection |
+| `/health` | never | liveness probe |
+
+`/health` returns `{"status":"ok","version":"<crate version>"}` and is
+deliberately outside the bearer layer, so an orchestrator can probe the process
+without holding API credentials. It reports nothing about loaded state — use
+`/api/stats` for that.
+
+</details>
+
 ### Build your first ontology
 
 ```text

--- a/src/main.rs
+++ b/src/main.rs
@@ -1143,6 +1143,25 @@ async fn async_main() -> anyhow::Result<()> {
             } else {
                 router
             };
+            // Liveness probe. Registered AFTER the bearer layer on purpose:
+            // `Router::layer` only wraps the routes already present, so adding
+            // /health here leaves it outside the auth middleware while /api and
+            // /mcp stay behind it. Putting it inside the `if let` branch above,
+            // or before the layer call, would make it require credentials in the
+            // one deployment where an unauthenticated probe is the point.
+            //
+            // The body is deliberately limited to status and version: an
+            // unauthenticated endpoint should not describe loaded state, which is
+            // exactly why /api/stats is not the right thing to probe.
+            let router = router.route(
+                "/health",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({
+                        "status": "ok",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    }))
+                }),
+            );
             let router = router.layer(tower_http::cors::CorsLayer::permissive());
             let addr = format!("{host}:{port}");
             let listener = tokio::net::TcpListener::bind(&addr).await?;


### PR DESCRIPTION
Closes #68.

## What this does

`/health` returns `{"status":"ok","version":"<crate version>"}` from `env!("CARGO_PKG_VERSION")` — status and version only, nothing describing loaded state, since an unauthenticated endpoint reporting triple counts is the reason `/api/stats` is the wrong thing to probe. `/health` rather than `/healthz`, and only one of them.

## On the registration point

Your correction about the conditional bearer check was the load-bearing part, and it turns out the ordering has to go one step further than "outer router, not the guarded branch". `Router::layer` wraps only the routes already present, so a route registered *before* the layer call is still wrapped by it even though it lives on the outer router. `/health` therefore has to be registered **after** the `if let Some(ref token)` block, not before it.

I measured both orderings rather than reasoning about them. Server started with `--token s3cr3t-test`:

| | as merged (after the layer) | registered before the layer |
|---|---|---|
| `GET /health` no auth | **200** `{"status":"ok","version":"1.1.1"}` | **401** |
| `GET /health` with auth | 200 | 200 |
| `GET /api/stats` no auth | 401 | 401 |
| `GET /api/stats` with auth | 200 | 200 |

So the wrong ordering reproduces exactly the problem the issue describes, in exactly the deployment where it matters. The code comment records this so the next reader does not have to rediscover it.

## README

There is no `serve-http` section in the README today, so this adds a minimal `<details>` block under "Connect to your MCP client" with a three-row route table and the auth posture of each. Move or reshape it however fits — I did not want to invent a larger section unprompted.

`cargo clippy --all-targets -- -D warnings` clean; `cargo test --lib` 251 passed, 0 failed.
