### PR TITLE
ci(release): attest build provenance and publish SHASUMS.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # attest-build-provenance signs through Sigstore with the workflow's OIDC
+      # identity and writes the attestation back to the repository, so it needs
+      # both on top of the existing contents: write.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -57,6 +62,19 @@ jobs:
               mv "${dir}open-ontologies" "${dir}open-ontologies-${target}"
             fi
           done
+      - name: Generate SHASUMS.txt
+        run: |
+          # Strip the artifact directory so the listed names match the asset
+          # names as downloaded, and keep sha256sum's two-space separator so
+          # `sha256sum -c SHASUMS.txt` works as-is next to the binaries.
+          sha256sum open-ontologies-*/open-ontologies-* | sed 's|  .*/|  |' > SHASUMS.txt
+          cat SHASUMS.txt
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          # Runs after the rename so each attested subject name is the name the
+          # asset is published under.
+          subject-path: 'open-ontologies-*/open-ontologies-*'
       - name: Extract release notes from CHANGELOG
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -68,4 +86,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: release-notes.md
-          files: open-ontologies-*/open-ontologies-*
+          files: |
+            open-ontologies-*/open-ontologies-*
+            SHASUMS.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Added
+- **Build provenance and checksums on release binaries.** The release job now
+  emits a Sigstore attestation via `actions/attest-build-provenance`, binding
+  each published binary to the workflow run and the commit it was built from,
+  and publishes a `SHASUMS.txt` alongside the assets. Verify with
+  `gh attestation verify <binary> --repo fabio-rovai/open-ontologies`, or
+  `sha256sum -c SHASUMS.txt` next to the downloaded files. The release job
+  gains `id-token: write` and `attestations: write` for the signing identity.
 - **Opt-in persistent triple store.** A new `[storage]` section selects the
   backend for the main graph: `mode = "memory"` (default, unchanged behaviour)
   or `mode = "persistent"`, which opens a RocksDB-backed Oxigraph store at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,26 @@ All notable changes to Open Ontologies are documented here.
 - **Build provenance and checksums on release binaries.** The release job now
   emits a Sigstore attestation via `actions/attest-build-provenance`, binding
   each published binary to the workflow run and the commit it was built from,
-  and publishes a `SHASUMS.txt` alongside the assets. Verify with
-  `gh attestation verify <binary> --repo fabio-rovai/open-ontologies`, or
-  `sha256sum -c SHASUMS.txt` next to the downloaded files. The release job
-  gains `id-token: write` and `attestations: write` for the signing identity.
+  and publishes a `SHASUMS.txt` alongside the assets. The release job gains
+  `id-token: write` and `attestations: write` for the signing identity.
+
+  Verify provenance with:
+
+  ```
+  gh attestation verify <binary> --repo fabio-rovai/open-ontologies
+  ```
+
+  Or check the checksum of the binary you downloaded. `SHASUMS.txt` lists all
+  four platforms, so verify the one you have rather than the whole file:
+
+  ```
+  grep open-ontologies-x86_64-unknown-linux-gnu SHASUMS.txt | sha256sum -c -
+  # macOS: ... | shasum -a 256 -c -
+  ```
+
+  A bare `sha256sum -c SHASUMS.txt` expects all four binaries present and exits
+  non-zero when three are missing, which is the normal case. With GNU coreutils
+  you can also pass `--ignore-missing`; the form above works on macOS too.
 - **Opt-in persistent triple store.** A new `[storage]` section selects the
   backend for the main graph: `mode = "memory"` (default, unchanged behaviour)
   or `mode = "persistent"`, which opens a RocksDB-backed Oxigraph store at


### PR DESCRIPTION
Closes #77.

Provenance rather than only checksums, as you asked. Both are in, since a `SHASUMS.txt` is still the more convenient thing to pin in a script that does not want a `gh attestation verify` dependency — but the attestation is the one that answers the question the issue was actually about.

## What changes

`actions/attest-build-provenance@v4` signs through Sigstore with the workflow's OIDC identity and binds each artifact to the workflow run and the commit. The job gains `id-token: write` for that identity and `attestations: write` to write the attestation back, on top of the existing `contents: write`.

`SHASUMS.txt` is generated from the renamed binaries and published as a release asset.

Consumers get either of:

```bash
gh attestation verify open-ontologies-x86_64-unknown-linux-gnu --repo fabio-rovai/open-ontologies
sha256sum -c SHASUMS.txt
```

## Three details worth a look

**The attestation runs after the rename.** Before it, all four artifacts are still called `open-ontologies`, so attesting there would sign the same subject name four times and none of them would match a published asset. Placing it after means every attested subject is the name the asset is actually downloaded under.

**SHASUMS.txt is verifiable as-is, not just readable.** The paths in the artifact tree are `open-ontologies-<target>/open-ontologies-<target>`, so a raw `sha256sum` output would list directory-qualified names that no downloader has. The `sed` strips the directory and keeps sha256sum's two-space separator, which is what `-c` parses. Checked against a mock artifact tree including the `.exe`:

```
$ sha256sum -c SHASUMS.txt
open-ontologies-aarch64-apple-darwin: OK
open-ontologies-x86_64-apple-darwin: OK
open-ontologies-x86_64-pc-windows-msvc.exe: OK
open-ontologies-x86_64-unknown-linux-gnu: OK
```

**Pinned to `@v4`**, the current major — worth stating because the widely-copied snippets still say `@v1`.

## Out of scope on purpose

`release.yml:34` still builds without `--features`. That is the other half of #67, and you said you wanted to decide separately whether the shipped binary carries the feature set or whether that stays a build-from-source path. Changing what the published artifact contains is your call, not a side effect of a hardening patch.

CHANGELOG entry under `[Unreleased]`.

I cannot exercise this end to end without pushing a tag on your repo, so the first real run is a tag push here. If the attestation step surprises you, the likely candidate is the subject-path glob against the artifact layout `download-artifact` produces.
