### PR TITLE
docs(data-pipeline): document the SQL type to XSD contract, versioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Added
+- **Versioned SQL type → XSD datatype contract.** `docs/data-pipeline.md` now
+  documents what `SchemaIntrospector::sql_to_xsd` produces for every SQL type it
+  recognises, alongside the declarative `datatype` mapping field it is easy to
+  confuse it with. The table is marked v1 and any row that changes gets a
+  CHANGELOG entry, so a `schema.rs` refactor can no longer alter the shape of
+  generated ontologies invisibly. Also records the decisions the table encodes
+  (parameters stripped, timezone not represented, `xsd:string` catch-all) and
+  what the schema import derives beyond the datatype.
 - **Opt-in persistent triple store.** A new `[storage]` section selects the
   backend for the main graph: `mode = "memory"` (default, unchanged behaviour)
   or `mode = "persistent"`, which opens a RocksDB-backed Oxigraph store at

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -112,6 +112,99 @@ accepted by `onto_ingest` (file rows) and `onto_sql_ingest` (SQL rows).
 When a mapping is omitted, `onto_ingest` / `onto_sql_ingest` auto-generate one
 from the column names so you can iterate fast and refine later.
 
+## SQL type → XSD datatype contract (v1)
+
+The `datatype` field documented just above is **declarative**: you write it, and
+`onto_ingest` / `onto_sql_ingest` honour it. This section is about the other
+mechanism — the **automatic** one. When `onto_import_schema` reads a live
+Postgres or DuckDB schema, nothing declares the datatypes; `SchemaIntrospector::sql_to_xsd`
+(`src/schema.rs`) infers them from the SQL type names. The two are easy to
+conflate and behave differently: a declared `datatype` is never overridden by
+this table, and this table never applies to a mapping you wrote by hand.
+
+Treat what follows as a contract. It is versioned, and any change to a row gets
+a CHANGELOG entry, because a change here silently alters the shape of every
+ontology generated downstream.
+
+### The table
+
+| SQL type (case-insensitive, parameters stripped) | XSD datatype |
+|---|---|
+| `integer` `int` `int4` `bigint` `int8` `smallint` `int2` `tinyint` `int1` `hugeint` `serial` `bigserial` `smallserial` `ubigint` `uinteger` `usmallint` `utinyint` | `xsd:integer` |
+| `numeric` `decimal` | `xsd:decimal` |
+| `real` `float4` | `xsd:float` |
+| `double precision` `double` `float8` `float` | `xsd:double` |
+| `boolean` `bool` | `xsd:boolean` |
+| `date` | `xsd:date` |
+| `timestamp` `timestamptz` `timestamp with time zone` `timestamp without time zone` `datetime` | `xsd:dateTime` |
+| `time` `time with time zone` `time without time zone` | `xsd:time` |
+| `bytea` `blob` | `xsd:hexBinary` |
+| `uuid` | `xsd:string` |
+| **anything else** | `xsd:string` |
+
+### The decisions behind it
+
+Each of these is defensible on its own and invisible without a document, which
+is the reason this page exists.
+
+**Parameters are stripped before matching.** `DECIMAL(18,2)` and `DECIMAL(38,10)`
+both become a bare `xsd:decimal`; `VARCHAR(255)` becomes `xsd:string`. Precision
+and scale are not represented in the range. If you need them enforced, express
+them with SHACL rather than expecting the range to carry them.
+
+**IEEE 754 floats are not `xsd:decimal`.** The value space of `xsd:decimal` is
+integers over powers of ten, so it cannot represent `NaN`, `INF` or `-INF`, and
+asserting it would claim an exactness the column does not have. `real` and
+`float4` are `xsd:float`; `double precision`, `double` and `float8` are
+`xsd:double`.
+
+**Bare `float` widens to `xsd:double`.** It is genuinely dialect-dependent —
+Postgres reads it as `float8`, DuckDB as an alias of `REAL`. Widening is the
+safe direction: every `xsd:float` value is exactly representable as an
+`xsd:double`, so calling a DuckDB single a double overstates the range without
+misrepresenting a value, whereas the reverse would declare a range narrower
+than the data. `float(p)` normalises to this arm as well.
+
+**Timezone information is not represented.** `timestamp with time zone` and
+`timestamp without time zone` both map to `xsd:dateTime`. XSD does distinguish
+them through the presence of an offset in the lexical form, but the range does
+not record which flavour the column was.
+
+**`uuid` is `xsd:string`, not `xsd:anyURI`.** A UUID is not a locator, and
+`xsd:string` keeps round-tripping lossless.
+
+**The catch-all is the one to watch.** Any type not listed above becomes
+`xsd:string` silently — DuckDB `LIST`, `STRUCT` and `MAP`, Postgres `jsonb`,
+arrays, `interval`, `inet`, enums, and domain types. A structured column
+becomes an untyped literal with no warning. If your schema leans on those,
+override the mapping explicitly rather than relying on inference.
+
+### What else the schema import decides
+
+The datatype is one of four things `onto_import_schema` derives, and the others
+matter when reading the generated ontology:
+
+- **Foreign key columns never reach this table.** They become an
+  `owl:ObjectProperty` whose `rdfs:range` is the parent class, not a datatype
+  property.
+- **Primary key columns** get `owl:FunctionalProperty` in addition to
+  `owl:DatatypeProperty`.
+- **`NOT NULL` columns** add an `owl:Restriction` subclass axiom with
+  `owl:minCardinality 1`.
+- **Property names** are `<table>_<column>`; class names are the table name in
+  PascalCase.
+
+### Versioning
+
+**v1** — the table above, first documented against the tree that includes the
+float-mapping correction (`real`/`float4` → `xsd:float`, `float8`/`double`/`float`
+→ `xsd:double`, previously all `xsd:decimal`).
+
+Any row that changes bumps this section and gets a CHANGELOG entry under
+`### Changed`. A refactor of `sql_to_xsd` that alters output without one is a
+breaking change to every downstream integrator at once, which is precisely what
+this contract exists to prevent.
+
 ## SQL ingest in three modes
 
 ### 1. Pull from PostgreSQL
@@ -186,6 +279,11 @@ The same query runs identically as MCP from Claude:
 `onto_import_schema` introspects a database, generates OWL, and loads it into
 the triple store. The same command works against PostgreSQL **and** DuckDB —
 only the connection string changes.
+
+The datatypes it infers are not ad hoc: see
+[SQL type → XSD datatype contract](#sql-type--xsd-datatype-contract-v1) for the
+full table, the catch-all behaviour, and what the import decides beyond the
+datatype (foreign keys, primary keys, `NOT NULL`).
 
 ```bash
 # Import a PostgreSQL schema as OWL (requires --features postgres)

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -175,9 +175,23 @@ not record which flavour the column was.
 
 **The catch-all is the one to watch.** Any type not listed above becomes
 `xsd:string` silently — DuckDB `LIST`, `STRUCT` and `MAP`, Postgres `jsonb`,
-arrays, `interval`, `inet`, enums, and domain types. A structured column
-becomes an untyped literal with no warning. If your schema leans on those,
-override the mapping explicitly rather than relying on inference.
+arrays, `interval`, `inet`, enums, and domain types. A structured column gets
+`rdfs:range xsd:string` with no warning.
+
+The declarative `datatype` field above **cannot** correct this.
+`SchemaIntrospector::generate_turtle` takes only the introspected tables and a
+base IRI; it never reads a mapping, and `import-schema` accepts no mapping
+argument. A mapping governs the literals ingest produces later, not the ranges
+the schema import asserts — so setting one leaves the generated ontology
+unchanged and can leave the two disagreeing. Two remedies that do work:
+
+- **Cast before importing.** Import from a view that presents the column as a
+  type in the table above. Effective for domain types, aliases and anything
+  numeric-adjacent; it cannot rescue a `STRUCT`.
+- **Amend the range after importing.** The generated ontology is loaded into
+  the triple store, so a SPARQL `UPDATE` replacing the `rdfs:range` of the
+  affected property is a supported edit. Pair it with SHACL when the real
+  constraint is richer than a datatype.
 
 ### What else the schema import decides
 
@@ -187,12 +201,21 @@ matter when reading the generated ontology:
 - **Foreign key columns never reach this table.** They become an
   `owl:ObjectProperty` whose `rdfs:range` is the parent class, not a datatype
   property.
-- **Primary key columns** get `owl:FunctionalProperty` in addition to
-  `owl:DatatypeProperty`.
+- **Primary key columns that are not also foreign keys** get
+  `owl:FunctionalProperty` in addition to `owl:DatatypeProperty`. The foreign
+  key branch is taken first, so a shared primary key — the 1:1 pattern where a
+  table's PK is also an FK to its parent — yields an `owl:ObjectProperty` only,
+  with no functional axiom.
 - **`NOT NULL` columns** add an `owl:Restriction` subclass axiom with
   `owl:minCardinality 1`.
-- **Property names** are `<table>_<column>`; class names are the table name in
-  PascalCase.
+- **Property names** are `<table>_<column>`; class names are the table name
+  split on `_` with each segment capitalised. That is PascalCase for
+  snake_case identifiers, which is the assumed shape. It is only a split on
+  underscores: a quoted identifier containing spaces or hyphens passes through
+  unchanged, so `"order details"` yields the class `Order details` and the
+  property `db:order details_qty` — neither of which is a valid Turtle
+  prefixed name. Sanitise such identifiers, or import through a view that
+  renames them.
 
 ### Versioning
 


### PR DESCRIPTION
Closes #76.

Written against the tree including #80, not against what `main` looked like when the issue was filed.

## Where it lives, and why

`docs/data-pipeline.md`, directly after the declarative `datatype` section, with the distinction you asked for stated up front: one mechanism is written by the operator and honoured as-is, the other is inferred by `sql_to_xsd` and never overrides it. Conflating them is the easy mistake, and having the two sections adjacent is what makes the difference legible.

There is also a pointer from **Schema → ontology in 3 commands**, since that is where a reader arrives when they actually run the import.

## The table is verified exhaustive, not transcribed

I extracted the match arms from `src/schema.rs` and diffed them against the table both ways:

```
arms in code: 39 | rows in doc: 39
missing from doc: none
extra in doc:     none
```

A hand-copied table that drifts one arm is worse than no table, so this seemed worth mechanising rather than eyeballing.

## What it records beyond the table

Each of these is defensible alone and invisible undocumented, which is the argument the issue was making:

- parameters stripped, so `DECIMAL(18,2)` and `DECIMAL(38,10)` are both a bare `xsd:decimal` — with a pointer to SHACL if precision must be enforced;
- IEEE 754 floats are not `xsd:decimal`, with the `NaN`/`INF` reasoning from your fix;
- bare `float` widens to `xsd:double` because the dialects disagree, and widening is the direction that overstates a range without misrepresenting a value;
- timezone is not represented in the range;
- `uuid` is `xsd:string` rather than `xsd:anyURI`;
- the `xsd:string` catch-all, flagged as the row to watch, since DuckDB `LIST` / `STRUCT` / `MAP` and Postgres `jsonb`, arrays, `interval` and enums all land there silently.

It also documents what the import decides **beyond** the datatype, because it changes how the generated ontology reads and none of it is obvious from the type table: foreign key columns never reach `sql_to_xsd` at all (they become an `owl:ObjectProperty` ranged on the parent class), primary keys gain `owl:FunctionalProperty`, and `NOT NULL` adds an `owl:minCardinality 1` restriction.

## Versioning

Marked **v1**, with the rule stated inside the section rather than only in a commit message: a row that changes bumps the version and gets a CHANGELOG entry under `### Changed`. The point being that a `schema.rs` refactor which alters output without one is a breaking change to every downstream integrator simultaneously.

CHANGELOG entry under `[Unreleased]`.

Docs only, no code change. Reshape the placement however suits you — I kept the section self-contained so it can move without dangling.
