### PR TITLE
ci: build, lint and test the optional features, and catch dark test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   # dependency trees they pull in (sqlx, duckdb, tract-onnx, tokenizers,
   # instant-distance).
   #
-  # It is also why seven test files under tests/ had never been collected once.
+  # It is also why eight test files under tests/ had never been collected once.
   # tests/schema_test.rs is gated on `postgres` and covers
   # SchemaIntrospector::sql_to_xsd, which carried a real defect the whole time
   # (#76, fixed in #80): the test existed, and it was dark.
@@ -61,6 +61,7 @@ jobs:
           # Breadth: everything compiles and lints, including causal-pywhy,
           # whose Rust side has no dependencies of its own.
           - name: breadth (all-features)
+            cache_key: breadth
             flags: --all-features
             test: false
           # Depth: everything whose tests run without external services.
@@ -68,9 +69,9 @@ jobs:
           # to Python/DoWhy at runtime, which is a service dependency in all but
           # name. It is still compiled and linted by the breadth leg.
           - name: depth (postgres,duckdb,embeddings,sql)
+            cache_key: depth
             flags: --features postgres,duckdb,embeddings,sql
             test: true
-            features_list: postgres duckdb embeddings sql
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
@@ -88,9 +89,12 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          # Keyed on the feature set: the legs build disjoint dependency trees,
-          # and sharing one cache between them would thrash it on every run.
-          key: ${{ matrix.name }}
+          # Keyed per leg: they build disjoint dependency trees, and sharing one
+          # cache between them would thrash it on every run. Not `matrix.name` —
+          # GitHub rejects cache keys containing commas, and the rejection is a
+          # log annotation rather than a failing step, so the leg would keep
+          # running uncached and silent.
+          key: ${{ matrix.cache_key }}
       - name: Check
         run: cargo check ${{ matrix.flags }} --all-targets
       - name: Clippy
@@ -104,4 +108,7 @@ jobs:
           cargo test ${{ matrix.flags }} 2>&1 | tee cargo-test.log
       - name: Verify every enabled test file collected tests
         if: matrix.test
-        run: bash scripts/check-test-collection.sh cargo-test.log "${{ matrix.features_list }}"
+        # Same flags as the test step, so the enabled set cannot drift from what
+        # was actually built. The script expands them through [features], which
+        # a hand-written list would not: `sql` implies postgres + duckdb.
+        run: bash scripts/check-test-collection.sh cargo-test.log "${{ matrix.flags }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,71 @@ jobs:
         run: |
           cargo install cargo-audit
           cargo audit
+
+  # Optional features are compiled by nothing above: `default = []`, and the
+  # three cargo invocations in `build` are bare. A green run there says nothing
+  # about postgres, duckdb, sql, embeddings or causal-pywhy, nor about the
+  # dependency trees they pull in (sqlx, duckdb, tract-onnx, tokenizers,
+  # instant-distance).
+  #
+  # It is also why seven test files under tests/ had never been collected once.
+  # tests/schema_test.rs is gated on `postgres` and covers
+  # SchemaIntrospector::sql_to_xsd, which carried a real defect the whole time
+  # (#76, fixed in #80): the test existed, and it was dark.
+  #
+  # Ubuntu only. The bundled duckdb build dominates wall time and Windows would
+  # double it for no signal the Linux leg does not already give.
+  features:
+    name: features / ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Breadth: everything compiles and lints, including causal-pywhy,
+          # whose Rust side has no dependencies of its own.
+          - name: breadth (all-features)
+            flags: --all-features
+            test: false
+          # Depth: everything whose tests run without external services.
+          # causal-pywhy is left out here rather than everywhere — it shells out
+          # to Python/DoWhy at runtime, which is a service dependency in all but
+          # name. It is still compiled and linted by the breadth leg.
+          - name: depth (postgres,duckdb,embeddings,sql)
+            flags: --features postgres,duckdb,embeddings,sql
+            test: true
+            features_list: postgres duckdb embeddings sql
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/local/share/chromium /usr/local/share/edge
+          sudo apt-get clean
+          df -h
+      - name: Install build deps (OpenSSL/libpq)
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Keyed on the feature set: the legs build disjoint dependency trees,
+          # and sharing one cache between them would thrash it on every run.
+          key: ${{ matrix.name }}
+      - name: Check
+        run: cargo check ${{ matrix.flags }} --all-targets
+      - name: Clippy
+        # --all-targets so the gated tests are linted too. `-D warnings` over
+        # code that is never compiled is not a check.
+        run: cargo clippy ${{ matrix.flags }} --all-targets -- -D warnings
+      - name: Test
+        if: matrix.test
+        run: |
+          set -o pipefail
+          cargo test ${{ matrix.flags }} 2>&1 | tee cargo-test.log
+      - name: Verify every enabled test file collected tests
+        if: matrix.test
+        run: bash scripts/check-test-collection.sh cargo-test.log "${{ matrix.features_list }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Added
+- **CI builds, lints and tests the optional features.** A `features` job adds a
+  breadth leg (`cargo check` + `cargo clippy --all-targets` at `--all-features`)
+  and a depth leg (`cargo test --features postgres,duckdb,embeddings,sql`), with
+  `rust-cache` keyed per feature set. `default = []`, so none of `postgres`,
+  `duckdb`, `sql`, `embeddings` or `causal-pywhy` — nor the `sqlx`, `duckdb`,
+  `tract-onnx`, `tokenizers` and `instant-distance` trees — was compiled by
+  anything in CI before this.
+
+  `scripts/check-test-collection.sh` fails the run when a test file whose gate
+  is enabled collects zero tests. Seven files under `tests/` had never been
+  collected once, 53 tests in total; a file that collects nothing reports
+  "test result: ok" and is indistinguishable from a passing one. Files whose
+  gate is off in a given leg are skipped, so partial-feature legs stay green.
 - **Opt-in persistent triple store.** A new `[storage]` section selects the
   backend for the main graph: `mode = "memory"` (default, unchanged behaviour)
   or `mode = "persistent"`, which opens a RocksDB-backed Oxigraph store at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ All notable changes to Open Ontologies are documented here.
   `tract-onnx`, `tokenizers` and `instant-distance` trees — was compiled by
   anything in CI before this.
 
+  The first run of the breadth leg found `clippy::large_enum_variant` in
+  `src/embed.rs`, a lint that could not have fired before because nothing
+  compiled `embeddings`.
+
   `scripts/check-test-collection.sh` fails the run when a test file whose gate
-  is enabled collects zero tests. Seven files under `tests/` had never been
-  collected once, 53 tests in total; a file that collects nothing reports
-  "test result: ok" and is indistinguishable from a passing one. Files whose
+  is enabled collects zero tests. Eight files under `tests/` had never been
+  collected once, 56 tests in total; a file that collects nothing reports
+  "test result: ok" and is indistinguishable from a passing one. The enabled
+  set is derived from the cargo flags the test step used and expanded through
+  `[features]`, so `--features sql` counts as postgres + duckdb; files whose
   gate is off in a given leg are skipped, so partial-feature legs stay green.
 - **Opt-in persistent triple store.** A new `[storage]` section selects the
   backend for the main graph: `mode = "memory"` (default, unchanged behaviour)

--- a/scripts/check-test-collection.sh
+++ b/scripts/check-test-collection.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Fail when an integration test file compiles to a target that collects no tests.
+#
+# `cargo test` prints "running 0 tests" followed by "test result: ok" for a file
+# whose `#![cfg(feature = "...")]` header is not satisfied. That is
+# indistinguishable from passing, which is the worst version of this failure:
+# a green badge over a file that has never run.
+#
+# tests/schema_test.rs sat behind `#![cfg(feature = "postgres")]` while CI ran a
+# bare `cargo test`, so its six tests were never collected once — including the
+# one asserting against `SchemaIntrospector::sql_to_xsd`, which carried a real
+# defect the whole time (IEEE 754 columns mapped to xsd:decimal, fixed in #80).
+#
+# A file whose gate is NOT in the enabled set is skipped: not being built is
+# expected there, and flagging it would make the check permanently red on any
+# partial-feature leg.
+#
+# Usage: bash scripts/check-test-collection.sh <cargo-test-log> "<enabled features>"
+#
+set -euo pipefail
+
+log=${1:?usage: check-test-collection.sh <cargo-test-log> "<enabled features>"}
+enabled=" ${2:-} "
+
+[ -f "$log" ] || { echo "::error::log file not found: $log"; exit 1; }
+
+missing=()
+empty=()
+checked=0
+
+for f in tests/*.rs; do
+    [ -e "$f" ] || continue
+
+    # File-level gate, if any: `#![cfg(feature = "x")]` in the header.
+    gate=$(sed -n '1,12p' "$f" \
+        | sed -n 's/^#!\[cfg(feature = "\([A-Za-z0-9_-]*\)")\].*/\1/p' \
+        | head -1)
+
+    if [ -n "$gate" ] && [[ "$enabled" != *" $gate "* ]]; then
+        continue
+    fi
+
+    checked=$((checked + 1))
+
+    # cargo prints:  Running tests/foo.rs (target/debug/deps/foo-<hash>)
+    # then, after a blank line:  running N tests
+    count=$(awk -v target="$f" '
+        index($0, "Running " target " ") { seen = 1; next }
+        seen && $1 == "running" { print $2; exit }
+    ' "$log")
+
+    if [ -z "$count" ]; then
+        missing+=("$f")
+    elif [ "$count" -eq 0 ]; then
+        empty+=("$f")
+    fi
+done
+
+status=0
+
+if [ ${#empty[@]} -gt 0 ]; then
+    for f in "${empty[@]}"; do
+        echo "::error file=$f::collected 0 tests while its feature gate is enabled"
+    done
+    status=1
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+    for f in "${missing[@]}"; do
+        echo "::error file=$f::no test target ran for this file"
+    done
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "test collection OK — $checked test file(s) expected under [${2:-none}], all collected at least one test"
+else
+    echo
+    echo "A test file that collects nothing reports \"test result: ok\" and is"
+    echo "indistinguishable from a passing file. Either its gate is wrong, or the"
+    echo "feature set this leg enables no longer matches the files it should build."
+fi
+
+exit "$status"

--- a/scripts/check-test-collection.sh
+++ b/scripts/check-test-collection.sh
@@ -164,7 +164,14 @@ for f in tests/*.rs; do
 
     # cargo prints:  Running tests/foo.rs (target/debug/deps/foo-<hash>)
     # then, after a blank line:  running N tests
+    #
+    # The "Running" banner is colourised, and CI sets CARGO_TERM_COLOR=always,
+    # so the SGR reset sits between the word and the path. Strip CSI sequences
+    # before matching — a plain substring search finds nothing otherwise, and
+    # the failure is total rather than partial: every file looks unbuilt.
     count=$(awk -v target="$f" '
+        BEGIN { esc = sprintf("%c", 27) }
+        { gsub(esc "\\[[0-9;]*[a-zA-Z]", "") }
         index($0, "Running " target " ") { seen = 1; next }
         seen && $1 == "running" { print $2; exit }
     ' "$log")
@@ -186,9 +193,20 @@ if [ ${#empty[@]} -gt 0 ]; then
 fi
 
 if [ ${#missing[@]} -gt 0 ]; then
-    for f in "${missing[@]}"; do
-        echo "::error file=$f::no test target ran for this file"
-    done
+    # Not one finding per file: when nothing at all was located, the log is not
+    # what this script thinks it is, and printing 48 identical errors buries
+    # that. (It happened: CARGO_TERM_COLOR=always put an SGR reset between
+    # "Running" and the path, and every file looked unbuilt.)
+    if [ ${#missing[@]} -eq "$checked" ] && [ "$checked" -gt 1 ]; then
+        echo "::error::no test target was found for any of the $checked expected files"
+        echo "The log does not look like \`cargo test\` output at all. Check that the"
+        echo "test step really wrote it, and that the \"Running <path>\" banner still"
+        echo "has the format this script parses."
+    else
+        for f in "${missing[@]}"; do
+            echo "::error file=$f::no test target ran for this file"
+        done
+    fi
     status=1
 fi
 

--- a/scripts/check-test-collection.sh
+++ b/scripts/check-test-collection.sh
@@ -3,9 +3,9 @@
 # Fail when an integration test file compiles to a target that collects no tests.
 #
 # `cargo test` prints "running 0 tests" followed by "test result: ok" for a file
-# whose `#![cfg(feature = "...")]` header is not satisfied. That is
-# indistinguishable from passing, which is the worst version of this failure:
-# a green badge over a file that has never run.
+# whose feature gate is not satisfied. That is indistinguishable from passing,
+# which is the worst version of this failure: a green badge over a file that has
+# never run.
 #
 # tests/schema_test.rs sat behind `#![cfg(feature = "postgres")]` while CI ran a
 # bare `cargo test`, so its six tests were never collected once — including the
@@ -16,28 +16,147 @@
 # expected there, and flagging it would make the check permanently red on any
 # partial-feature leg.
 #
-# Usage: bash scripts/check-test-collection.sh <cargo-test-log> "<enabled features>"
+# The enabled set is derived from the same cargo flags the test step used, and
+# expanded through `[features]` in Cargo.toml, so `--features sql` correctly
+# counts as postgres + duckdb. Passing a hand-written list instead would go
+# stale silently, in the direction that hides files rather than flagging them.
+#
+# Two gate forms are recognised, because both are in use here:
+#   #![cfg(feature = "x")]              — inner attribute, gates the whole file
+#   #[cfg(feature = "x")] mod tests {}  — outer attribute over the only test mod
+# Anything more intricate (several distinct gates, tests outside the gated mod)
+# is treated as ungated, i.e. expected to collect. When the shape is unclear the
+# check errs toward checking: a spurious red is loud and takes a minute to fix,
+# a spurious green is the bug this script exists to prevent.
+#
+# Platform gates (`#![cfg(unix)]` in tests/socket_test.rs) are out of scope: the
+# features job runs on Linux only, where that file does collect.
+#
+# Usage: bash scripts/check-test-collection.sh <cargo-test-log> "<cargo flags>"
+#   bash scripts/check-test-collection.sh cargo-test.log "--features postgres,sql"
+#   bash scripts/check-test-collection.sh cargo-test.log "--all-features"
 #
 set -euo pipefail
 
-log=${1:?usage: check-test-collection.sh <cargo-test-log> "<enabled features>"}
-enabled=" ${2:-} "
+log=${1:?usage: check-test-collection.sh <cargo-test-log> "<cargo flags>"}
+flags=${2:-}
 
 [ -f "$log" ] || { echo "::error::log file not found: $log"; exit 1; }
+[ -f Cargo.toml ] || { echo "::error::Cargo.toml not found — run from the crate root"; exit 1; }
 
+# --- what Cargo.toml declares -------------------------------------------------
+# One "<name><TAB><comma-separated members>" line per [features] entry. Handles
+# arrays spread over several lines, and strips comments.
+feature_table=$(awk '
+    /^[[:space:]]*\[/ { in_f = ($0 ~ /^[[:space:]]*\[features\][[:space:]]*$/); next }
+    in_f { line = $0; sub(/#.*/, "", line); buf = buf " " line }
+    END {
+        while (match(buf, /[A-Za-z0-9_-]+[[:space:]]*=[[:space:]]*\[[^]]*\]/)) {
+            entry = substr(buf, RSTART, RLENGTH)
+            buf   = substr(buf, RSTART + RLENGTH)
+            name  = substr(entry, 1, index(entry, "=") - 1)
+            gsub(/[[:space:]]/, "", name)
+            members = substr(entry, index(entry, "[") + 1)
+            sub(/\][[:space:]]*$/, "", members)
+            gsub(/[" \t]/, "", members)
+            print name "\t" members
+        }
+    }
+' Cargo.toml)
+
+[ -n "$feature_table" ] || { echo "::error::no [features] section found in Cargo.toml"; exit 1; }
+
+# --- what the cargo flags enable ----------------------------------------------
+all_features=0
+no_default=0
+seeds=""
+
+set -- $flags
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --all-features)        all_features=1 ;;
+        --no-default-features) no_default=1 ;;
+        --features|-F)         shift; seeds="$seeds $(printf '%s' "${1:-}" | tr ',' ' ')" ;;
+        --features=*)          seeds="$seeds $(printf '%s' "${1#--features=}" | tr ',' ' ')" ;;
+        -F*)                   seeds="$seeds $(printf '%s' "${1#-F}" | tr ',' ' ')" ;;
+    esac
+    shift
+done
+
+if [ "$all_features" -eq 1 ]; then
+    seeds=$(printf '%s\n' "$feature_table" | cut -f1 | tr '\n' ' ')
+elif [ "$no_default" -eq 0 ]; then
+    seeds="$seeds default"
+fi
+
+# Transitive closure over [features]. `dep:foo` and `pkg/feat` entries name
+# dependencies, not gates of ours, and are dropped.
+queue=$seeds
+enabled=""
+while [ -n "${queue// /}" ]; do
+    name=${queue%% *}
+    if [ "$name" = "$queue" ]; then queue=""; else queue=${queue#* }; fi
+    [ -n "$name" ] || continue
+    case " $enabled " in *" $name "*) continue ;; esac
+    enabled="$enabled $name"
+    members=$(printf '%s\n' "$feature_table" | awk -F'\t' -v n="$name" '$1 == n { print $2 }')
+    for m in $(printf '%s' "$members" | tr ',' ' '); do
+        case "$m" in dep:*|*/*) continue ;; esac
+        queue="$queue $m"
+    done
+done
+enabled=" ${enabled# } "
+
+# --- check every test file ----------------------------------------------------
 missing=()
 empty=()
 checked=0
+skipped=0
 
 for f in tests/*.rs; do
     [ -e "$f" ] || continue
 
-    # File-level gate, if any: `#![cfg(feature = "x")]` in the header.
-    gate=$(sed -n '1,12p' "$f" \
-        | sed -n 's/^#!\[cfg(feature = "\([A-Za-z0-9_-]*\)")\].*/\1/p' \
-        | head -1)
+    # Gate for the whole file, or empty when the file is (or looks) ungated.
+    gate=$(awk '
+        /^#!\[cfg\(/ {
+            line = $0
+            while (match(line, /"[A-Za-z0-9_-]+"/)) {
+                crate = crate " " substr(line, RSTART + 1, RLENGTH - 2)
+                line  = substr(line, RSTART + RLENGTH)
+            }
+            next
+        }
+        /^#\[cfg\(feature[[:space:]]*=[[:space:]]*"[A-Za-z0-9_-]+"\)\][[:space:]]*$/ {
+            match($0, /"[A-Za-z0-9_-]+"/)
+            g = substr($0, RSTART + 1, RLENGTH - 2)
+            outer++
+            if (mod_gate == "")      mod_gate = g
+            else if (mod_gate != g)  mixed = 1
+            if (tests > 0)           late = 1
+            next
+        }
+        /^[[:space:]]*#\[(tokio::)?test\]/ { tests++ }
+        END {
+            if (tests == 0)                                  { print "__no_tests__"; exit }
+            if (crate != "")                                 { print substr(crate, 2); exit }
+            if (outer == 1 && !mixed && !late)               { print mod_gate; exit }
+            print ""
+        }
+    ' "$f")
 
-    if [ -n "$gate" ] && [[ "$enabled" != *" $gate "* ]]; then
+    if [ "$gate" = "__no_tests__" ]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Several gates on one file (`#![cfg(all(feature = "a", feature = "b"))]`)
+    # all have to be enabled for its tests to exist.
+    gate_off=0
+    for g in $gate; do
+        case "$enabled" in *" $g "*) ;; *) gate_off=1 ;; esac
+    done
+    if [ "$gate_off" -eq 1 ]; then
+        skipped=$((skipped + 1))
         continue
     fi
 
@@ -73,8 +192,10 @@ if [ ${#missing[@]} -gt 0 ]; then
     status=1
 fi
 
+echo "enabled features:${enabled}"
+
 if [ "$status" -eq 0 ]; then
-    echo "test collection OK — $checked test file(s) expected under [${2:-none}], all collected at least one test"
+    echo "test collection OK — $checked test file(s) expected, all collected at least one test ($skipped skipped as gated out)"
 else
     echo
     echo "A test file that collects nothing reports \"test result: ok\" and is"

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -137,6 +137,14 @@ impl TextEmbedder {
 
 /// Unified text embedder that dispatches to either the local ONNX model or
 /// an OpenAI-compatible HTTP API, selected by configuration.
+// clippy::large_enum_variant fires here (Local is ~1.4 KB against ~100 bytes for
+// OpenAI) and the lint had never run, because nothing in CI compiled the
+// `embeddings` feature. Boxing is not the right answer for this one: the value
+// is built once at startup and immediately parked in an `Arc` (server.rs), then
+// only ever borrowed — it is never moved in a hot path or stored in a
+// collection. The box would buy an indirection on every embed call and change a
+// public type, to save a single move of 1.4 KB at boot.
+#[allow(clippy::large_enum_variant)]
 pub enum TextEmbedderProvider {
     Local(TextEmbedder),
     OpenAI(crate::embed_remote::OpenAIEmbedder),


### PR DESCRIPTION
Closes #67.

Two legs, plus the loud failure for zero-collection you asked for in the bump.

## Breadth and depth

**Breadth** — `cargo check --all-features --all-targets` and `cargo clippy --all-features --all-targets -- -D warnings`. Clippy gets `--all-targets` because, as you put it, `-D warnings` over code that is never compiled is not a check; without it the gated test files are not linted either.

**Depth** — `cargo test --features postgres,duckdb,embeddings,sql`.

`causal-pywhy` is left out of the **depth** leg only. It shells out to Python/DoWhy at runtime, which is a service dependency in all but name. It is still compiled and linted by the breadth leg, which is where you said it comes for free.

Ubuntu only. The bundled duckdb build dominates wall time and a Windows leg would double it for no signal the Linux one does not already give.

`rust-cache` is keyed per leg. It was already in the workflow, but shared — and the legs build disjoint dependency trees, so one key between them would thrash on every run.

## One deviation: postgres is in the depth leg

You scoped it out because the service container is more machinery than you wanted in a first PR. It turns out not to need one.

`tests/schema_test.rs` contains no connection string, no `async`, no `tokio::test` — its six tests are pure functions over `sql_to_xsd`. And a full `cargo test --features postgres,duckdb,embeddings,sql` on `eb0ef41` gives **595 passed, 0 failed**, with no Postgres running anywhere on the machine.

Leaving it out would have left `tests/schema_test.rs` dark, which is the file that motivated reframing this issue. Dropping `postgres,` from the depth leg is a one-line revert if you would rather hold the original scope; a service container is still needed the day someone writes a test that actually connects.

## The zero-collection check

`scripts/check-test-collection.sh` reads each `tests/*.rs` header for its `#![cfg(feature = "...")]` gate. A file whose gate is enabled must appear in the cargo output **and** report a non-zero count. A file whose gate is off in that leg is skipped.

That skip is the part a plain grep for `running 0 tests` gets wrong, and it is why this is a script rather than a one-liner: the lib and bin unittest targets and Doc-tests legitimately report zero, and so does every gated file on a leg that does not enable it. A naive check would be red on every run.

Deriving the expectation from the gate rather than from an allowlist means it stays correct when a test file is added, gated or ungated, with nothing to maintain.

Exercised against faithful cargo output covering all 48 test files:

| case | result |
|---|---|
| all features on, everything collects | OK — 48 expected, exit 0 |
| `schema_test.rs` at 0 while `postgres` enabled | one precise `::error file=…`, exit 1 |
| partial leg, postgres files compile empty | 47 expected, no false positive, exit 0 |

## Costs

`cargo check --features duckdb,embeddings` is **6m49 cold** here with the bundled duckdb build, so the depth gate looks viable per-PR with the cache rather than needing the nightly schedule you offered as a fallback. The first run on each leg pays the full build while the cache fills — worth knowing before judging the numbers.

## Out of scope on purpose

`release.yml:34` still builds without `--features`. You said you wanted to decide separately whether the shipped binary carries the feature set, and #83 leaves it alone for the same reason.

I cannot exercise the workflow itself without your CI — the script is tested locally, the YAML parses, but the first real run is here. If something surprises you, the likeliest candidates are the disk headroom on the breadth leg (`--all-features` plus bundled duckdb is heavy, hence the `Free disk space` step) and the cache key namespacing.
