### PR TITLE
fix(ci): stop an unbounded apt-get from hanging CI to the 6 hour ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,16 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded branch runs are cancelled; main runs are kept so every commit
+# keeps its own status. Three pushes to main landed inside 33 minutes on
+# 2026-08-18 and each one started a fresh 6 hour hang.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,6 +54,7 @@ jobs:
   # stayed clean and the failure surfaced as an unexplained build break. This
   # job names the offending paths in seconds.
   paths:
+    timeout-minutes: 10
     name: paths / windows-safe
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +84,7 @@ jobs:
   # Ubuntu only. The bundled duckdb build dominates wall time and Windows would
   # double it for no signal the Linux leg does not already give.
   features:
+    timeout-minutes: 45
     name: features / ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
@@ -106,7 +116,32 @@ jobs:
           sudo apt-get clean
           df -h
       - name: Install build deps (OpenSSL/libpq)
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev
+        # The runner image already ships all three of these, so the common case
+        # is a no-op: the step logged "0 upgraded, 0 newly installed" every time
+        # it succeeded. Its only real effect was an unconditional network call.
+        # On 2026-08-18 the Azure apt mirror went dark, apt fell back to
+        # archive.ubuntu.com, stalled mid-transfer, and sat there with no
+        # timeout until GitHub killed the job at the 6 hour ceiling (runs
+        # 32156117278 and 32157458411, 5h58m of silence after the last Get:).
+        # So: touch the network only when something is genuinely missing, and
+        # bound apt when it is.
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          missing=()
+          for p in pkg-config libssl-dev libpq-dev; do
+            dpkg -s "$p" >/dev/null 2>&1 || missing+=("$p")
+          done
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "Build deps already present on the image; skipping apt."
+            exit 0
+          fi
+          echo "Missing build deps: ${missing[*]}"
+          sudo apt-get -o Acquire::Retries=3 \
+                       -o Acquire::http::Timeout=30 \
+                       -o Acquire::https::Timeout=30 update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                       --no-install-recommends "${missing[@]}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -146,6 +181,7 @@ jobs:
   # runs at publish time tells you about the defect after the artefact is
   # public.
   python:
+    timeout-minutes: 15
     name: python (open-ontologies-lite)
     runs-on: ubuntu-latest
     steps:
@@ -171,6 +207,7 @@ jobs:
   # crate. Type-checking is the part that catches the errors a reviewer cannot
   # see by reading a diff.
   studio:
+    timeout-minutes: 15
     name: studio (typecheck)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +30,26 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install Linux build deps (OpenSSL/libpq)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev
+        # Same guard as ci.yml. An unbounded `apt-get update` hung CI for the
+        # full 6 hour job ceiling when the Azure mirror went dark; on the
+        # release path that would stall a tagged build just as silently.
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          missing=()
+          for p in pkg-config libssl-dev libpq-dev; do
+            dpkg -s "$p" >/dev/null 2>&1 || missing+=("$p")
+          done
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "Build deps already present on the image; skipping apt."
+            exit 0
+          fi
+          echo "Missing build deps: ${missing[*]}"
+          sudo apt-get -o Acquire::Retries=3 \
+                       -o Acquire::http::Timeout=30 \
+                       -o Acquire::https::Timeout=30 update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                       --no-install-recommends "${missing[@]}"
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Upload binary
@@ -39,6 +59,7 @@ jobs:
           path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
   release:
+    timeout-minutes: 20
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
CI on `main` has not been hanging by accident: `features / breadth (all-features)` stalled in **Install build deps (OpenSSL/libpq)** until GitHub cancelled it at the 6 hour job ceiling, twice in a row (runs 32156117278 and 32157458411).

## The mechanism

The cancelled job log ends here, then goes silent for 5h58m:

```
15:45:21  Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
15:45:29  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
21:43:36  ##[error]The operation was canceled.
```

The Azure mirror stopped answering, apt fell back to `archive.ubuntu.com`, and wedged mid-transfer on a half-open connection. No lock contention and no interactive prompt, so `-y` was never the issue.

It is a race, not a property of `main`. The `depth` leg runs the identical step and cleared it in 6 seconds on the same run; `breadth` simply lost the race twice.

## The step installed nothing

From the `depth` log, same step, same runner image:

```
pkg-config is already the newest version (1.8.1-2build1).
libssl-dev is already the newest version (3.0.13-0ubuntu3.12).
libpq-dev is already the newest version (18.4-1.pgdg24.04+1).
0 upgraded, 0 newly installed, 0 to remove and 12 not upgraded.
```

All three ship on the runner image. The step never installed anything; its only practical effect was to put Ubuntu mirror availability on the critical path of every build.

## Changes

- **Consult `dpkg` first.** Skip apt entirely when the packages are present, which is the normal case, so the common path makes no network call at all. If one is genuinely absent, apt runs with `Acquire::Retries=3` and 30s http/https timeouts, under `timeout-minutes: 5`. Same guard applied to `release.yml`, where an identical stall would hold a tagged build just as silently.
- **`timeout-minutes` on all seven jobs** across both workflows. Nothing here had a timeout, which is the reason a stalled download cost six hours rather than five minutes. This is the part that makes the next flake, wherever it lands, survivable.
- **A `concurrency` group on CI.** Three pushes to `main` landed inside 33 minutes and each started its own 6 hour hang. Branch runs now supersede each other; `main` runs are preserved so every commit keeps its own status.

`DEBIAN_FRONTEND` is set through `sudo env` rather than `sudo VAR=value`, which depends on the sudoers `setenv` policy and fails outright where it is not granted.

## Verification

- `actionlint 1.7.7` clean on both workflows.
- YAML parses; timeouts confirmed on all seven jobs.
- The shell logic was exercised against stubbed `dpkg`/`apt-get`/`sudo`/`env` in both branches: all-present exits 0 without invoking apt, and a missing `libpq-dev` invokes apt for that package alone.

Note that the earlier Windows `exit code 128` failures are a separate fault, already fixed by a014eb1; `build (windows-latest)` and `paths / windows-safe` are green on the most recent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)