### PR TITLE
Vacuous conformance reporting, and closed-world checking on the pip path

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -116,7 +116,41 @@ Register it with any MCP client (e.g. Claude):
 | `onto_diff` | Triple-level diff between two ontologies |
 | `onto_kgcl_diff` | KGCL change records between two versions (governance / change logs) |
 | `onto_lint` | Missing labels, domains, ranges |
-| `onto_shacl` | SHACL conformance: violations with focus node, path, value, severity and constraint (needs the `[shacl]` extra) |
+| `onto_shacl` | SHACL conformance: violations with focus node, path, value, severity and constraint, plus `focus_nodes` and `unmatched_shapes` (needs the `[shacl]` extra) |
+| `onto_vocab_check` | Closed-world check: which terms in the data are not declared in the loaded ontology |
+
+### Closed-world checking
+
+RDF is open-world, so a predicate nobody declared is unknown rather than wrong.
+An extractor that invents `ex:hasProteinName` because it sounded plausible
+produces RDF that parses, loads and satisfies SHACL without a murmur. Closing
+that world is the only way to tell an invented term from a real one:
+
+```python
+from open_ontologies_lite import vocab_check
+
+report = vocab_check(ontology_ttl, generated_data_ttl)
+report["undeclared_terms"]   # ['http://example.org/onto#hasProteinName']
+```
+
+Instance IRIs are never policed, because individuals belong to the data rather
+than the vocabulary, and the standard vocabularies are never policed either.
+With no ontology loaded the check reports that nothing was checked and returns
+`conforms: False`, never `True`: a green light from an empty vocabulary is the
+failure this exists to prevent.
+
+### Validation that never passes vacuously
+
+A shapes graph whose targets match nothing validates every constraint against
+the empty set and reports `conforms: True`, byte-identical to a run where every
+constraint was checked and passed. `shacl_validate` reports how many focus nodes
+were actually selected and names the shapes that selected none:
+
+```python
+report["focus_nodes"]        # 0
+report["unmatched_shapes"]   # [{'shape': '...PersonShape', 'target_class': '...Person'}]
+report["conforms"]           # None, because nothing was examined
+```
 
 ## Relationship to the Rust engine
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-ontologies-lite"
-version = "0.3.0"
+version = "0.4.0"
 description = "Lightweight Python bridge to the Oxigraph RDF/OWL engine, MCP server included. No Rust toolchain, no compilation."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "pyoxigraph>=0.5,<0.6",
-    "mcp>=1.2",
+    "mcp>=1.2,<2",
 ]
 
 [project.optional-dependencies]

--- a/python/src/open_ontologies_lite/__init__.py
+++ b/python/src/open_ontologies_lite/__init__.py
@@ -5,14 +5,16 @@ Oxigraph RDF/OWL engine. No Rust toolchain, no compilation, prebuilt wheels only
 from .dataframe import rows_from_dataframe, rows_to_turtle
 from .engine import OntologyEngine, ValidationResult, resolve_format
 from .kgcl import ChangeSet, kgcl_diff
+from .vocab_check import vocab_check
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __all__ = [
     "OntologyEngine",
     "ValidationResult",
     "resolve_format",
     "ChangeSet",
     "kgcl_diff",
+    "vocab_check",
     "rows_from_dataframe",
     "rows_to_turtle",
     "__version__",

--- a/python/src/open_ontologies_lite/server.py
+++ b/python/src/open_ontologies_lite/server.py
@@ -120,6 +120,29 @@ def onto_shacl(
     )
 
 
+@mcp.tool()
+def onto_vocab_check(
+    data: str, data_format: str = "turtle", extra_namespaces: list[str] | None = None
+) -> dict:
+    """Closed-world check: which terms in `data` are not declared in the loaded ontology.
+
+    RDF is open-world, so an invented predicate is merely unknown and passes both
+    parsing and SHACL untouched. This closes that world against the loaded
+    ontology and names every undeclared term in the namespaces that ontology owns.
+    Instance IRIs and the standard vocabularies are never policed.
+
+    Returns False for `conforms`, never True, when no vocabulary is loaded.
+    """
+    from .vocab_check import vocab_check
+
+    return vocab_check(
+        _engine.dump(),
+        data,
+        data_format=data_format,
+        extra_namespaces=extra_namespaces,
+    )
+
+
 def main() -> None:
     import argparse
 

--- a/python/src/open_ontologies_lite/shacl.py
+++ b/python/src/open_ontologies_lite/shacl.py
@@ -32,6 +32,68 @@ def _local(term: str) -> str:
     return term[len(SH) :] if term.startswith(SH) else term
 
 
+def _focus_nodes(data_graph, shapes_graph) -> tuple[int, list[dict]]:
+    """Count the nodes each shape actually selected.
+
+    A shapes graph whose targets match nothing validates every constraint against
+    the empty set and reports conformance, which is indistinguishable from a run
+    that examined the data and found it sound. Counting the selected nodes is
+    what separates "checked and clean" from "checked nothing".
+
+    Only the four declarative target predicates are counted. A shape with no
+    declared target, or one using SPARQL-based `sh:target`, is not judged here:
+    reporting it as unmatched would be a guess.
+    """
+    import rdflib
+
+    sh = rdflib.Namespace(SH)
+    rdfs = rdflib.RDFS
+
+    total = 0
+    unmatched: list[dict] = []
+
+    for shape in set(shapes_graph.subjects(rdflib.RDF.type, sh.NodeShape)):
+        selected: set = set()
+        declared = False
+
+        for target_class in shapes_graph.objects(shape, sh.targetClass):
+            declared = True
+            # SHACL selects SHACL-instances, so instances of subclasses count.
+            selected.update(data_graph.subjects(rdflib.RDF.type, target_class))
+            for sub in data_graph.transitive_subjects(rdfs.subClassOf, target_class):
+                selected.update(data_graph.subjects(rdflib.RDF.type, sub))
+
+        for node in shapes_graph.objects(shape, sh.targetNode):
+            declared = True
+            selected.add(node)
+
+        for prop in shapes_graph.objects(shape, sh.targetSubjectsOf):
+            declared = True
+            selected.update(data_graph.subjects(prop, None))
+
+        for prop in shapes_graph.objects(shape, sh.targetObjectsOf):
+            declared = True
+            selected.update(data_graph.objects(None, prop))
+
+        if not declared:
+            continue
+
+        total += len(selected)
+        if not selected:
+            unmatched.append(
+                {
+                    "shape": str(shape),
+                    "target_class": next(
+                        (str(t) for t in shapes_graph.objects(shape, sh.targetClass)),
+                        "",
+                    ),
+                }
+            )
+
+    unmatched.sort(key=lambda u: (u["target_class"], u["shape"]))
+    return total, unmatched
+
+
 def shacl_validate(
     data: str,
     shapes: str,
@@ -50,14 +112,17 @@ def shacl_validate(
     pyshacl = _require_pyshacl()
     import rdflib
 
+    data_graph = rdflib.Graph().parse(data=data, format=data_format)
+    shapes_graph = rdflib.Graph().parse(data=shapes, format=shapes_format)
+
     conforms, results_graph, results_text = pyshacl.validate(
-        data,
-        shacl_graph=shapes,
-        data_graph_format=data_format,
-        shacl_graph_format=shapes_format,
+        data_graph,
+        shacl_graph=shapes_graph,
         inference=inference,
         advanced=True,
     )
+
+    focus_nodes, unmatched_shapes = _focus_nodes(data_graph, shapes_graph)
 
     sh = rdflib.Namespace(SH)
     violations: list[dict] = []
@@ -81,10 +146,25 @@ def shacl_validate(
     for v in violations:
         by_severity[v["severity"]] = by_severity.get(v["severity"], 0) + 1
 
-    return {
+    report = {
         "conforms": bool(conforms),
         "count": len(violations),
         "by_severity": by_severity,
         "violations": violations,
+        "focus_nodes": focus_nodes,
+        "unmatched_shapes": unmatched_shapes,
         "text": results_text,
     }
+
+    # Every shape that declared a target selected nothing, so no constraint was
+    # applied to anything. Reporting conformance here would be the same lie as
+    # reporting it for a constraint that never ran.
+    if focus_nodes == 0 and unmatched_shapes:
+        report["conforms"] = None
+        report["warning"] = (
+            f"no focus node was selected: all {len(unmatched_shapes)} targeted shape(s) "
+            "match nothing in the data, so conformance is undetermined. "
+            "See unmatched_shapes."
+        )
+
+    return report

--- a/python/src/open_ontologies_lite/vocab_check.py
+++ b/python/src/open_ontologies_lite/vocab_check.py
@@ -1,0 +1,148 @@
+"""Closed-world vocabulary checking against a declared ontology.
+
+RDF is open-world: an IRI nobody declared is unknown, not wrong. That is the
+right default for the web and the wrong one for checking a generated graph,
+because an extractor that invents `ex:hasProteinName` because it sounded
+plausible produces RDF that parses, loads and satisfies SHACL without complaint.
+Nothing in the standard toolchain objects.
+
+This module closes that world deliberately. It reads the vocabulary an ontology
+declares, works out which namespaces that ontology owns, and reports every term
+used in the data that sits in one of those namespaces without being declared.
+
+Two rules keep it honest. Instance IRIs are never policed, because individuals
+belong to the data rather than the vocabulary. And a check with no vocabulary
+loaded never returns a pass, because a green light from an empty ontology is the
+exact failure this exists to prevent.
+
+Runs on pyoxigraph, the same engine as everything else here, so it needs no
+dependency beyond the base install and answers as the Rust engine's
+`vocab_check` does.
+"""
+
+from __future__ import annotations
+
+import pyoxigraph as ox
+
+from .engine import resolve_format
+
+OWL = "http://www.w3.org/2002/07/owl#"
+RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+RDFS = "http://www.w3.org/2000/01/rdf-schema#"
+
+#: Vocabularies every graph is entitled to use without declaring them.
+STD_NS = (
+    RDF,
+    RDFS,
+    OWL,
+    "http://www.w3.org/2001/XMLSchema#",
+    "http://www.w3.org/ns/shacl#",
+    "http://www.w3.org/2004/02/skos/core#",
+)
+
+_CLASS_OR_PROPERTY = f"""FILTER(
+    ?k = <{OWL}Class>
+ || ?k = <{RDFS}Class>
+ || ?k = <{OWL}ObjectProperty>
+ || ?k = <{OWL}DatatypeProperty>
+ || ?k = <{OWL}AnnotationProperty>
+ || ?k = <{OWL}FunctionalProperty>
+ || ?k = <{OWL}InverseFunctionalProperty>
+ || ?k = <{RDF}Property>)"""
+
+# An ontology that gives an IRI a domain or a range has declared it in substance,
+# even without typing it, so those axioms count as declarations too.
+_DEFINING_AXIOM = f"""FILTER(
+    ?p = <{RDFS}domain>
+ || ?p = <{RDFS}range>
+ || ?p = <{RDFS}subClassOf>
+ || ?p = <{RDFS}subPropertyOf>)"""
+
+
+def _namespace_of(iri: str) -> str:
+    """Everything up to and including the last `#` or `/`."""
+    cut = max(iri.rfind("#"), iri.rfind("/"))
+    return iri[: cut + 1] if cut >= 0 else iri
+
+
+def _store_from(text: str, fmt: str) -> ox.Store:
+    store = ox.Store()
+    if text.strip():
+        store.load(text.encode("utf-8"), format=resolve_format(fmt))
+    return store
+
+
+def _iris(store: ox.Store, sparql: str, var: str) -> set[str]:
+    """Collect the IRI bindings of one variable; literals and blanks are skipped."""
+    out: set[str] = set()
+    for solution in store.query(sparql):
+        term = solution[var]
+        if isinstance(term, ox.NamedNode):
+            out.add(term.value)
+    return out
+
+
+def vocab_check(
+    ontology: str,
+    data: str,
+    *,
+    ontology_format: str = "turtle",
+    data_format: str = "turtle",
+    extra_namespaces: list[str] | None = None,
+) -> dict:
+    """Check `data` against the vocabulary `ontology` declares.
+
+    `extra_namespaces` polices namespaces the ontology does not own, which is how
+    you check data against a vocabulary you have not loaded.
+
+    Returns a report with `conforms`, `undeclared_terms`, the namespaces policed,
+    and the counts behind the verdict. `conforms` is False, never True, when
+    there was no vocabulary to check against.
+    """
+    onto_store = _store_from(ontology, ontology_format)
+    data_store = _store_from(data, data_format)
+
+    declared = _iris(
+        onto_store, f"SELECT DISTINCT ?t WHERE {{ ?t a ?k . {_CLASS_OR_PROPERTY} }}", "t"
+    ) | _iris(
+        onto_store, f"SELECT DISTINCT ?t WHERE {{ ?t ?p ?o . {_DEFINING_AXIOM} }}", "t"
+    )
+
+    extra = list(extra_namespaces or [])
+
+    # A closed-world check with nothing to close over must never silently pass.
+    if not declared and not extra:
+        return {
+            "conforms": False,
+            "undeclared_terms": [],
+            "checked_namespaces": [],
+            "predicates_checked": 0,
+            "types_checked": 0,
+            "ontology_terms": 0,
+            "warning": (
+                "no ontology vocabulary found (0 declared terms): load an ontology, "
+                "or pass extra_namespaces to police; nothing was checked"
+            ),
+        }
+
+    policed = {_namespace_of(term) for term in declared}
+    policed.update(extra)
+    policed.difference_update(STD_NS)
+
+    predicates = _iris(data_store, "SELECT DISTINCT ?p WHERE { ?s ?p ?o }", "p")
+    types = _iris(data_store, "SELECT DISTINCT ?c WHERE { ?s a ?c }", "c")
+
+    undeclared = sorted(
+        iri
+        for iri in predicates | types
+        if _namespace_of(iri) in policed and iri not in declared
+    )
+
+    return {
+        "conforms": not undeclared,
+        "undeclared_terms": undeclared,
+        "checked_namespaces": sorted(policed),
+        "predicates_checked": len(predicates),
+        "types_checked": len(types),
+        "ontology_terms": len(declared),
+    }

--- a/python/tests/test_shacl_vacuous.py
+++ b/python/tests/test_shacl_vacuous.py
@@ -1,0 +1,127 @@
+"""Vacuous conformance: shapes that selected no focus nodes.
+
+pySHACL answers `conforms: True` for a shapes graph whose targets match nothing,
+with no indication that nothing was examined. That report is byte-identical to
+one where every constraint ran and passed, so a pipeline gating on `conforms`
+publishes unvalidated data on a green light.
+
+The Rust engine reports `focus_nodes` and `unmatched_shapes` and withholds the
+verdict when nothing matched. These tests hold the Python package to the same
+contract, so the two surfaces cannot disagree about what a validation run means.
+"""
+
+import pytest
+
+pytest.importorskip("pyshacl", reason="needs the [shacl] extra")
+
+from open_ontologies_lite.shacl import shacl_validate  # noqa: E402
+
+# Shapes in one namespace, data in another: the mismatch that makes generated
+# shapes target nothing while every report still reads clean.
+SHAPES_OTHER_NAMESPACE = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shapes/> .
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+"""
+
+SHAPES_SAME_NAMESPACE = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+"""
+
+DATA = """
+@prefix ex: <http://example.org/> .
+ex:ada a ex:Person ; ex:name "Ada" .
+"""
+
+DATA_MISSING_NAME = """
+@prefix ex: <http://example.org/> .
+ex:ada a ex:Person .
+"""
+
+
+def test_shapes_that_select_nothing_are_named():
+    report = shacl_validate(DATA, SHAPES_OTHER_NAMESPACE)
+
+    assert report["focus_nodes"] == 0
+    assert [u["target_class"] for u in report["unmatched_shapes"]] == [
+        "http://example.org/shapes/Person"
+    ]
+
+
+def test_a_run_that_selected_nothing_withholds_the_verdict():
+    report = shacl_validate(DATA_MISSING_NAME, SHAPES_OTHER_NAMESPACE)
+
+    assert report["conforms"] is None, "nothing was checked, so there is no verdict"
+    assert "focus node" in report["warning"]
+
+
+def test_an_ordinary_passing_run_still_conforms():
+    report = shacl_validate(DATA, SHAPES_SAME_NAMESPACE)
+
+    assert report["conforms"] is True
+    assert report["focus_nodes"] == 1
+    assert report["unmatched_shapes"] == []
+
+
+def test_a_failing_run_is_unaffected():
+    report = shacl_validate(DATA_MISSING_NAME, SHAPES_SAME_NAMESPACE)
+
+    assert report["conforms"] is False
+    assert report["focus_nodes"] == 1
+    assert report["count"] == 1
+
+
+def test_subclass_instances_count_as_focus_nodes():
+    """SHACL selects SHACL-instances, so a subclass instance is a focus node."""
+    data = """
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix ex: <http://example.org/> .
+    ex:Employee rdfs:subClassOf ex:Person .
+    ex:ada a ex:Employee ; ex:name "Ada" .
+    """
+    report = shacl_validate(data, SHAPES_SAME_NAMESPACE)
+
+    assert report["focus_nodes"] == 1
+    assert report["unmatched_shapes"] == []
+
+
+def test_target_predicates_other_than_class_are_counted():
+    shapes = """
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix ex: <http://example.org/> .
+    ex:AuthoredShape a sh:NodeShape ;
+      sh:targetSubjectsOf ex:wrote ;
+      sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    """
+    data = """
+    @prefix ex: <http://example.org/> .
+    ex:ada ex:wrote ex:notes ; ex:name "Ada" .
+    """
+    report = shacl_validate(data, shapes)
+
+    assert report["focus_nodes"] == 1
+    assert report["unmatched_shapes"] == []
+    assert report["conforms"] is True
+
+
+def test_a_shape_with_no_declared_target_is_not_called_unmatched():
+    """Property shapes and advanced targets are not judged, only reported honestly."""
+    shapes = """
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix ex: <http://example.org/> .
+    ex:Floating a sh:NodeShape ;
+      sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    ex:PersonShape a sh:NodeShape ;
+      sh:targetClass ex:Person ;
+      sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    """
+    report = shacl_validate(DATA, shapes)
+
+    assert report["unmatched_shapes"] == []
+    assert report["focus_nodes"] == 1

--- a/python/tests/test_vocab_check.py
+++ b/python/tests/test_vocab_check.py
@@ -1,0 +1,121 @@
+"""Closed-world vocabulary checking.
+
+In the open world an undeclared IRI is unknown, not wrong, so an extractor that
+invents `ex:hasProteinName` produces RDF that parses, loads and passes SHACL
+without complaint. Closed-world checking is the only thing that separates a real
+term from a plausible-looking one, and it is the check that has no equivalent
+elsewhere in the Python RDF stack.
+
+Mirrors the semantics of the Rust engine's `vocab_check`: police the namespaces
+the ontology itself declares terms in, never instance IRIs, never the standard
+vocabularies, and refuse to return a pass when there is no vocabulary to check
+against.
+"""
+
+import pytest
+
+pytest.importorskip("pyoxigraph")
+
+from open_ontologies_lite.vocab_check import vocab_check  # noqa: E402
+
+ONTOLOGY = """
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://example.org/onto#> .
+
+ex:Person a owl:Class .
+ex:Protein a owl:Class .
+ex:hasName a owl:DatatypeProperty ; rdfs:domain ex:Person .
+"""
+
+CLEAN_DATA = """
+@prefix ex: <http://example.org/onto#> .
+<http://example.org/instances/ada> a ex:Person ; ex:hasName "Ada" .
+"""
+
+INVENTED_TERM = """
+@prefix ex: <http://example.org/onto#> .
+<http://example.org/instances/ada> a ex:Person ; ex:hasProteinName "Ada" .
+"""
+
+
+def test_clean_data_conforms():
+    report = vocab_check(ONTOLOGY, CLEAN_DATA)
+
+    assert report["conforms"] is True
+    assert report["undeclared_terms"] == []
+    assert report["ontology_terms"] == 3
+
+
+def test_an_invented_predicate_is_flagged():
+    report = vocab_check(ONTOLOGY, INVENTED_TERM)
+
+    assert report["conforms"] is False
+    assert report["undeclared_terms"] == ["http://example.org/onto#hasProteinName"]
+
+
+def test_instance_iris_are_not_policed():
+    """Individuals live in the data, not the vocabulary; flagging them is noise."""
+    data = """
+    @prefix ex: <http://example.org/onto#> .
+    <http://example.org/onto#ada> a ex:Person ; ex:hasName "Ada" .
+    """
+    report = vocab_check(ONTOLOGY, data)
+
+    assert report["conforms"] is True, report["undeclared_terms"]
+
+
+def test_terms_outside_the_policed_namespaces_are_left_alone():
+    data = """
+    @prefix ex:   <http://example.org/onto#> .
+    @prefix dct:  <http://purl.org/dc/terms/> .
+    <http://example.org/instances/ada> a ex:Person ; dct:title "Ada" .
+    """
+    report = vocab_check(ONTOLOGY, data)
+
+    assert report["conforms"] is True
+    assert "http://purl.org/dc/terms/" not in report["checked_namespaces"]
+
+
+def test_standard_vocabularies_are_never_policed():
+    data = """
+    @prefix ex:   <http://example.org/onto#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    <http://example.org/instances/ada> a ex:Person ; rdfs:label "Ada" .
+    """
+    report = vocab_check(ONTOLOGY, data)
+
+    assert report["conforms"] is True
+
+
+def test_no_vocabulary_never_returns_a_pass():
+    """The footgun this check exists to kill: a green light from an empty ontology."""
+    report = vocab_check("", CLEAN_DATA)
+
+    assert report["conforms"] is False
+    assert "nothing was checked" in report["warning"]
+    assert report["ontology_terms"] == 0
+
+
+def test_extra_namespaces_can_be_policed_explicitly():
+    report = vocab_check(
+        "", INVENTED_TERM, extra_namespaces=["http://example.org/onto#"]
+    )
+
+    assert report["conforms"] is False
+    assert "http://example.org/onto#hasProteinName" in report["undeclared_terms"]
+
+
+def test_a_term_carrying_only_a_domain_axiom_counts_as_declared():
+    ontology = """
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix ex:   <http://example.org/onto#> .
+    ex:hasName rdfs:domain ex:Person .
+    """
+    data = """
+    @prefix ex: <http://example.org/onto#> .
+    <http://example.org/instances/ada> ex:hasName "Ada" .
+    """
+    report = vocab_check(ontology, data)
+
+    assert report["conforms"] is True

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,6 +577,19 @@ fn setup(data_dir: &str) -> anyhow::Result<(StateDb, Arc<GraphStore>)> {
     Ok((db, graph))
 }
 
+/// Whether the resolved storage backend keeps the graph in RAM only.
+///
+/// One-shot CLI subcommands each build their own store, so in this mode nothing
+/// a command loads is visible to the next one.
+fn is_memory_storage(data_dir: &str) -> bool {
+    use open_ontologies::config::{resolve_storage_mode, StorageMode};
+    let data_path = std::path::PathBuf::from(expand_tilde(data_dir));
+    let storage_cfg = open_ontologies::config::Config::load(&data_path.join("config.toml"))
+        .map(|c| c.storage)
+        .unwrap_or_default();
+    matches!(resolve_storage_mode(&storage_cfg), StorageMode::Memory)
+}
+
 /// Build the singleton main graph using the configured storage backend.
 ///
 /// In-memory: returns an empty `GraphStore`.
@@ -1436,10 +1449,24 @@ async fn async_main() -> anyhow::Result<()> {
         Commands::Load { path } => {
             let (_db, graph) = setup(&cli.data_dir)?;
             match graph.load_file(&path) {
-                Ok(count) => output_json(
-                    &serde_json::json!({"ok": true, "triples_loaded": count, "path": path}),
-                    cli.pretty,
-                ),
+                Ok(count) => {
+                    let mut report =
+                        serde_json::json!({"ok": true, "triples_loaded": count, "path": path});
+                    // In-memory is the default backend, so a one-shot `load`
+                    // fills a store that dies with the process. Saying only
+                    // "triples_loaded" here reads as durable, and the next
+                    // command reporting zero reads as data loss.
+                    if is_memory_storage(&cli.data_dir) {
+                        report["warning"] = serde_json::Value::String(
+                            "storage mode is 'memory', so this load did not persist: \
+                             a following command starts from an empty store. Set \
+                             [storage] mode = \"persistent\" or OPEN_ONTOLOGIES_STORAGE_MODE=persistent \
+                             to chain CLI commands."
+                                .to_string(),
+                        );
+                    }
+                    output_json(&report, cli.pretty)
+                }
                 Err(e) => {
                     output_json(&serde_json::json!({"error": e.to_string()}), cli.pretty);
                     std::process::exit(1);

--- a/src/shacl.rs
+++ b/src/shacl.rs
@@ -45,12 +45,30 @@ impl ShaclValidator {
 
         let mut violations: Vec<serde_json::Value> = Vec::new();
         let mut skipped: Vec<serde_json::Value> = Vec::new();
+        let mut unmatched: Vec<serde_json::Value> = Vec::new();
+        let mut focus_nodes_total: u64 = 0;
 
         for shape in &shapes {
             let target_class = match shape.get("targetClass") {
                 Some(tc) => strip_angle_brackets(tc),
                 None => continue,
             };
+
+            // How many nodes does this shape actually apply to? A shape whose
+            // target class appears nowhere in the data evaluates every one of
+            // its constraints against the empty set and contributes no
+            // violations, which is indistinguishable in the report from a shape
+            // that checked its nodes and found them sound.
+            let focus_count = count_focus_nodes(graph, &target_class)?;
+            focus_nodes_total += focus_count;
+            if focus_count == 0 {
+                unmatched.push(serde_json::json!({
+                    "shape": strip_angle_brackets(
+                        shape.get("shape").map(|s| s.as_str()).unwrap_or_default()
+                    ),
+                    "target_class": target_class,
+                }));
+            }
 
             // 3. Find property constraints for this shape
             let shape_iri = match shape.get("shape") {
@@ -412,11 +430,24 @@ impl ShaclValidator {
             }
         }
 
+        let nothing_matched = !shapes.is_empty() && focus_nodes_total == 0;
+
         let mut report = serde_json::json!({
             "violation_count": violations.len(),
             "violations": violations,
+            "focus_nodes": focus_nodes_total,
+            "unmatched_shapes": unmatched,
         });
-        if skipped.is_empty() {
+        if nothing_matched && skipped.is_empty() {
+            // Every shape targeted a class with no instances in the data, so
+            // nothing was checked. Reporting `conforms: true` here would be the
+            // same lie as reporting it for a constraint that never ran.
+            report["conforms"] = serde_json::Value::Null;
+            report["warning"] = serde_json::Value::String(format!(
+                "no focus nodes matched: all {} shape(s) target classes absent from the data, so conformance is undetermined. See unmatched_shapes.",
+                shapes.len()
+            ));
+        } else if skipped.is_empty() {
             report["conforms"] = serde_json::Value::Bool(violations.is_empty());
         } else {
             // Some constraints in this shapes graph were not evaluated, so no
@@ -698,6 +729,23 @@ fn is_recognised_xsd_datatype(iri: &str) -> bool {
 }
 
 /// Trim angle brackets from IRI strings like `<http://example.org/foo>`.
+/// Count the distinct nodes a `sh:targetClass` shape applies to.
+///
+/// Used to tell "checked and clean" apart from "checked nothing": a shape whose
+/// target class has no instances passes every constraint vacuously.
+fn count_focus_nodes(graph: &Arc<GraphStore>, target_class: &str) -> anyhow::Result<u64> {
+    let query = format!(
+        r#"SELECT (COUNT(DISTINCT ?focus) AS ?cnt) WHERE {{ ?focus a <{target_class}> }}"#
+    );
+    let rows = graph_sparql_select(graph, &query)?;
+    Ok(rows
+        .first()
+        .and_then(|row| row.get("cnt"))
+        .map(|c| strip_quotes(c))
+        .and_then(|c| c.parse::<u64>().ok())
+        .unwrap_or(0))
+}
+
 fn strip_angle_brackets(s: &str) -> String {
     let s = s.trim();
     if s.starts_with('<') && s.ends_with('>') {

--- a/tests/cli_load_ephemeral_test.rs
+++ b/tests/cli_load_ephemeral_test.rs
@@ -1,0 +1,74 @@
+//! `load` in one-shot CLI mode must say when nothing was kept.
+//!
+//! With the default in-memory storage backend every CLI invocation builds a
+//! fresh store, so `open-ontologies load data.ttl` populates a graph that is
+//! dropped when the process exits. It reported `{"ok": true, "triples_loaded": N}`
+//! and the very next `stats` reported zero, which reads as data loss rather than
+//! as the documented consequence of the storage mode.
+//!
+//! Same rule as the SHACL reports: a success-shaped answer must not stand in for
+//! something that did not persist.
+
+use std::process::Command;
+
+fn oo(dir: &tempfile::TempDir) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_open-ontologies"));
+    cmd.arg("--data-dir").arg(dir.path());
+    cmd
+}
+
+fn write_ttl(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let path = dir.path().join("data.ttl");
+    std::fs::write(
+        &path,
+        "@prefix ex: <http://example.org/> .\nex:alice a ex:Person .\n",
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn load_in_memory_mode_warns_that_the_store_is_not_persisted() {
+    let dir = tempfile::tempdir().unwrap();
+    let ttl = write_ttl(&dir);
+
+    let out = oo(&dir)
+        .env("OPEN_ONTOLOGIES_STORAGE_MODE", "memory")
+        .arg("load")
+        .arg(&ttl)
+        .output()
+        .unwrap();
+    let report: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("load emits JSON");
+
+    assert_eq!(report["ok"], serde_json::json!(true));
+    assert_eq!(report["triples_loaded"], serde_json::json!(1));
+    let warning = report["warning"]
+        .as_str()
+        .expect("in-memory load must carry a warning");
+    assert!(
+        warning.contains("persist"),
+        "warning should say the load did not persist, got: {warning}"
+    );
+}
+
+#[test]
+fn load_in_persistent_mode_carries_no_warning() {
+    let dir = tempfile::tempdir().unwrap();
+    let ttl = write_ttl(&dir);
+
+    let out = oo(&dir)
+        .env("OPEN_ONTOLOGIES_STORAGE_MODE", "persistent")
+        .arg("load")
+        .arg(&ttl)
+        .output()
+        .unwrap();
+    let report: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("load emits JSON");
+
+    assert_eq!(report["triples_loaded"], serde_json::json!(1));
+    assert!(
+        report["warning"].is_null(),
+        "a persisted load has nothing to warn about"
+    );
+}

--- a/tests/shacl_vacuous_target_test.rs
+++ b/tests/shacl_vacuous_target_test.rs
@@ -1,0 +1,122 @@
+//! Vacuous conformance: shapes that matched no focus nodes.
+//!
+//! A SHACL run whose shapes target classes that appear nowhere in the data
+//! produces `conforms: true, violation_count: 0` — byte-for-byte the report of a
+//! run where every constraint was checked and passed. The caller cannot tell the
+//! two apart, so a pipeline that validates before publishing gets a green light
+//! on data nothing looked at.
+//!
+//! This is the same failure the `sh:sparql` fix (#98) pinned down from the other
+//! direction: there, constraints were never executed; here, they execute against
+//! an empty target set. `ShaclValidator`'s stated contract is that reporting
+//! success for rules that were never run is the one failure mode it must not
+//! have, so these tests pin:
+//!
+//!   1. shapes matching zero focus nodes report which shapes matched nothing;
+//!   2. a run where nothing at all matched does not claim conformance;
+//!   3. an ordinary passing run still reports `conforms: true`, with the count;
+//!   4. a partial match keeps a real verdict but still names the empty shape.
+
+use open_ontologies::graph::GraphStore;
+use open_ontologies::shacl::ShaclValidator;
+use std::sync::Arc;
+
+fn store_with_people() -> Arc<GraphStore> {
+    let store = Arc::new(GraphStore::new());
+    let ttl = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice a ex:Person ; ex:fullName "Alice" .
+    "#;
+    store.load_turtle(ttl, None).unwrap();
+    store
+}
+
+fn report(store: &Arc<GraphStore>, shapes: &str) -> serde_json::Value {
+    serde_json::from_str(&ShaclValidator::validate(store, shapes).unwrap()).unwrap()
+}
+
+/// Shapes minted in one namespace, data in another: the exact shape of the
+/// mismatch that makes generated shapes silently target nothing.
+const SHAPES_WRONG_NAMESPACE: &str = r#"
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix ex: <http://example.org/shapes/> .
+    ex:PersonShape a sh:NodeShape ;
+        sh:targetClass ex:Person ;
+        sh:property [ sh:path ex:fullName ; sh:minCount 1 ] .
+"#;
+
+const SHAPES_RIGHT_NAMESPACE: &str = r#"
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix ex: <http://example.org/> .
+    ex:PersonShape a sh:NodeShape ;
+        sh:targetClass ex:Person ;
+        sh:property [ sh:path ex:fullName ; sh:minCount 1 ] .
+"#;
+
+#[test]
+fn shapes_that_match_nothing_are_named_in_the_report() {
+    let r = report(&store_with_people(), SHAPES_WRONG_NAMESPACE);
+
+    assert_eq!(
+        r["focus_nodes"],
+        serde_json::json!(0),
+        "a report that hides a zero target count cannot be distinguished from a real pass"
+    );
+    let unmatched = r["unmatched_shapes"]
+        .as_array()
+        .expect("unmatched_shapes must be present");
+    assert_eq!(unmatched.len(), 1);
+    assert_eq!(
+        unmatched[0]["target_class"],
+        "http://example.org/shapes/Person"
+    );
+}
+
+#[test]
+fn a_run_that_matched_nothing_does_not_claim_conformance() {
+    let r = report(&store_with_people(), SHAPES_WRONG_NAMESPACE);
+
+    assert_eq!(
+        r["conforms"],
+        serde_json::Value::Null,
+        "nothing was evaluated, so there is no conformance verdict to give"
+    );
+    assert_eq!(r["violation_count"], 0);
+}
+
+#[test]
+fn an_ordinary_passing_run_still_conforms() {
+    let r = report(&store_with_people(), SHAPES_RIGHT_NAMESPACE);
+
+    assert_eq!(r["conforms"], serde_json::json!(true));
+    assert_eq!(r["focus_nodes"], serde_json::json!(1));
+    assert!(
+        r["unmatched_shapes"].as_array().unwrap().is_empty(),
+        "the shape matched a focus node, so nothing is unmatched"
+    );
+}
+
+#[test]
+fn a_partial_match_keeps_its_verdict_and_still_names_the_empty_shape() {
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [ sh:path ex:fullName ; sh:minCount 1 ] .
+        ex:GadgetShape a sh:NodeShape ;
+            sh:targetClass ex:Gadget ;
+            sh:property [ sh:path ex:serial ; sh:minCount 1 ] .
+    "#;
+    let r = report(&store_with_people(), shapes);
+
+    assert_eq!(
+        r["conforms"],
+        serde_json::json!(true),
+        "one shape did evaluate, so the verdict stands"
+    );
+    assert_eq!(r["focus_nodes"], serde_json::json!(1));
+    let unmatched = r["unmatched_shapes"].as_array().unwrap();
+    assert_eq!(unmatched.len(), 1);
+    assert_eq!(unmatched[0]["target_class"], "http://example.org/Gadget");
+}


### PR DESCRIPTION
Two engines, one rule: a report must never present something that was not examined as something that passed.

## Rust engine

A shapes graph whose target classes are absent from the data validates every constraint against the empty set and returns `conforms: true, violation_count: 0`. That is byte-identical to a run where every constraint was checked and passed, so a pipeline gating on `conforms` publishes unvalidated data on a green light.

This is the #98 failure from the other side. There, constraints were never executed; here, they execute against nothing. `ShaclValidator` now reports `focus_nodes` and `unmatched_shapes` on every run and withholds the verdict when nothing matched at all. A partial match keeps its verdict and still names the empty shape, so a class with no instances yet does not void an otherwise valid run.

`load` also stops claiming a persistence it did not perform: with the default in-memory backend a one-shot CLI load reported `triples_loaded: N` while the next command saw zero.

## Python bridge (`open-ontologies-lite` 0.4.0)

The bridge is the only realistic install path for a Python project, and its SHACL delegated straight to pySHACL, which reports `conforms: True` for a shapes graph that matched nothing. Everything the engine offers over the standard stack was absent from the package a Python user would install.

- **`vocab_check`**: closed-world checking on the pip path. RDF is open-world, so an invented predicate is unknown rather than wrong and passes parsing and SHACL untouched. Runs on pyoxigraph, so no dependency beyond the base install, and mirrors the Rust semantics exactly.
- **`shacl_validate`** reports `focus_nodes` and `unmatched_shapes` and withholds the verdict on a vacuous run, so the two surfaces cannot disagree.
- **`onto_vocab_check`** added to the MCP tool surface.
- **`mcp<2` pinned**: 2.x removed `mcp.server.fastmcp`, so `server` failed to import on a fresh install of the published 0.3.0.

## Verification

64 Rust test binaries pass, zero failures. 40 Python tests pass, 2 skipped. New tests were written failing first: 4 in `tests/shacl_vacuous_target_test.rs`, 2 in `tests/cli_load_ephemeral_test.rs`, 7 in `python/tests/test_shacl_vacuous.py`, 8 in `python/tests/test_vocab_check.py`.

0.4.0 is published to PyPI via the `py-v0.4.0` tag and verified installing clean from the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)