### PR TITLE
chore(tests): repoint the two temporal.rs anchors the cap reporting moved

### DIFF
--- a/tests/temporal_conformance_test.rs
+++ b/tests/temporal_conformance_test.rs
@@ -337,7 +337,7 @@ fn boundary_touching_disjoint_assertions_are_superseded_not_contradictory() {
 // Everything above pins semantics that are intended. What follows pins what the
 // code does TODAY for mixed-precision and malformed bounds, which is a side
 // effect of comparing datatype-stripped literals lexically (`plain()` at
-// temporal.rs:92-105, `validities()` at :144-152) rather than a decision.
+// temporal.rs:229-242, `validities()` at :309-317) rather than a decision.
 //
 // These are the exact inputs the planned parsed-time work (issue #95, item 4)
 // changes: bounds parsed as instants on the UTC timeline accepting xsd:date,


### PR DESCRIPTION
Two line numbers in the conformance corpus, nothing else.

Section 2 of `tests/temporal_conformance_test.rs` explains that the accidental behaviour it pins is a side effect of comparing datatype-stripped literals lexically, and points the reader at the two functions responsible. Both ranges were written against the tree as it stood when #105 was opened, and #111 moved them:

| | was | is |
| --- | --- | --- |
| `plain()` | `temporal.rs:92-105` | `temporal.rs:229-242` |
| last-row-wins fold in `validities()` | `:144-152` | `:309-317` |

Comment only — no behaviour, no test, no changelog entry. But that comment exists so the next reader can confirm the claim in one jump, and a stale anchor costs them exactly that jump. Our drift, so worth fixing before the next diff lands on the same file.

I checked: this is the only code anchor of that shape anywhere in the repository, so there is nothing else to sweep.

Opening it first deliberately — the `recordedUntil` step of #109 edits `validities()` and item 4 of #95 rewrites section 2 of this corpus wholesale. Two lines out of the way now keeps both of those diffs readable.