### PR TITLE
fix(shacl): node-shape constraints reach the tri-state verdict too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A constraint asserted on the node shape itself was never evaluated and
+  never reported, so `sh:closed true` over data carrying an undeclared
+  predicate returned `conforms: true`.** The check that routes unimplemented
+  constraints to `skipped_constraints` reached one `sh:property` hop below the
+  shape and no further: `sh:closed`, a node-level `sh:not`, `sh:nodeKind`,
+  `sh:and`, `sh:or`, `sh:xone`, `sh:in` and `sh:node` never bound the
+  predicate it inspects. A second complement now covers the shape node, with a
+  whitelist of the predicates the validator reads there (the target forms,
+  `sh:property`, `sh:sparql`) plus the annotation predicates, which are never
+  constraints, so any other `sh:` predicate lands in `skipped_constraints` and
+  the verdict becomes null. The shape is bound as a query variable and matched
+  to the discovered shape, not spliced into the query text: a shape written
+  `[] a sh:NodeShape` is a blank node, and a blank-node label inside a SPARQL
+  query is a wildcard, not a name. The complement runs once per shape rather
+  than once per target class, so a node constraint is recorded once.
+  `sh:deactivated` is among them on purpose: a deactivated shape is still
+  evaluated here, so the predicate is not honoured and must not read as if it
+  were. The complement is restricted to the `sh:` namespace, because an
+  implicit class target carries its own class axioms on the same subject and
+  those are not constraints. A test now asserts the null verdict is reachable
+  from the node shape, from a property shape and from a target, each naming
+  its construct, so the next construct added has somewhere obvious to fail.
 - **A daemon started with `[http] token` in config rejected every command it was
   meant to serve.** `serve-http` falls back to the config token and then enforces
   bearer auth, but `daemon start` recorded `token: null` in `daemon.json`

--- a/src/shacl.rs
+++ b/src/shacl.rs
@@ -2,7 +2,7 @@ use crate::graph::GraphStore;
 use oxigraph::io::{RdfFormat, RdfParser};
 use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -15,8 +15,11 @@ use std::sync::Arc;
 ///
 /// Any constraint the validator cannot execute is recorded in
 /// `skipped_constraints` and suppresses the conformance verdict: `conforms`
-/// becomes null rather than true. Reporting success for rules that were never
-/// run is the one failure mode this validator must not have.
+/// becomes null rather than true. That holds wherever the constraint sits:
+/// on a property shape (`sh:not`), on the node shape itself (`sh:closed`,
+/// `sh:nodeKind`, `sh:deactivated`) or in a target form that is not selected
+/// (`sh:targetNode`). Reporting success for rules that were never run is the
+/// one failure mode this validator must not have.
 pub struct ShaclValidator;
 
 impl ShaclValidator {
@@ -85,6 +88,82 @@ impl ShaclValidator {
         }
         let mut unmatched: Vec<serde_json::Value> = Vec::new();
         let mut focus_nodes_total: u64 = 0;
+
+        // A constraint asserted on the node shape itself (`sh:closed`, a
+        // node-level `sh:not`, `sh:nodeKind`, `sh:and`, `sh:or`, `sh:xone`,
+        // `sh:in`, `sh:node`) never reaches the per-property complement in
+        // the loop below, which starts one sh:property hop under the shape.
+        // Before this complement existed, `sh:closed true` over data carrying
+        // an undeclared predicate returned `conforms: true`.
+        //
+        // It covers every discovered shape in one query, for two reasons.
+        // First, the shape is bound as a variable and matched to the
+        // discovery row by its printed term, not spliced into the query text:
+        // a shape written `[] a sh:NodeShape` prints as `_:label`, and a
+        // blank-node label inside a SPARQL query is a non-distinguished
+        // variable, not a name, so splicing it enumerated every predicate in
+        // the shapes graph and routed the property shape's own sh:path to
+        // skipped. Second, discovery yields one row per (shape, target class)
+        // and a node constraint belongs to the shape, so running the
+        // complement per row recorded `sh:closed` once per target class. It
+        // is restricted to discovered shapes, like the property complement:
+        // a shape using a target form this validator lacks is already
+        // recorded as skipped, and a shape with no target selects no focus
+        // nodes under SHACL, so its constraints not running is what the
+        // specification asks for, not a gap.
+        //
+        // The whitelist is the predicates the validator reads on the shape
+        // node (the four target forms, of which the three not implemented
+        // are already recorded as skipped above and must not be counted
+        // twice, sh:property and sh:sparql) plus the annotation predicates,
+        // which are never constraints. Any other sh: predicate lands in
+        // skipped, even one a later change starts to evaluate, because a
+        // whitelist that tracks what is implemented drifts the first time
+        // someone adds a constraint and forgets the list. `sh:deactivated` is
+        // deliberately absent: SHACL says a deactivated shape must not be
+        // evaluated and this validator evaluates it anyway, so the predicate
+        // is not implemented and must reach skipped like any other.
+        //
+        // The complement is restricted to the sh: namespace. A shape that is
+        // also an rdfs:Class or owl:Class (an implicit class target) carries
+        // the class's own axioms on the same subject (rdfs:subClassOf,
+        // rdfs:label, owl:equivalentClass), and an unrestricted complement
+        // would report those as constraints and turn every such run
+        // undetermined. A constraint is by definition a predicate in the sh:
+        // namespace; a predicate from any other namespace on a shape node is
+        // an annotation or an axiom, never a constraint.
+        let discovered: HashSet<&str> = shapes
+            .iter()
+            .filter_map(|s| s.get("shape").map(String::as_str))
+            .collect();
+        let unknown_on_node = query_solutions(
+            &shapes_store,
+            r#"
+            PREFIX sh: <http://www.w3.org/ns/shacl#>
+            SELECT DISTINCT ?shape ?pred WHERE {
+                ?shape a sh:NodeShape ; ?pred ?o .
+                FILTER(STRSTARTS(STR(?pred), "http://www.w3.org/ns/shacl#") && ?pred NOT IN (
+                    sh:targetClass, sh:targetNode, sh:targetSubjectsOf,
+                    sh:targetObjectsOf, sh:property, sh:sparql,
+                    sh:message, sh:severity, sh:name, sh:description,
+                    sh:order, sh:group
+                ))
+            }
+            "#,
+        )?;
+        for row in &unknown_on_node {
+            let (Some(shape), Some(pred)) = (row.get("shape"), row.get("pred")) else {
+                continue;
+            };
+            if !discovered.contains(shape.as_str()) {
+                continue;
+            }
+            skipped.push(serde_json::json!({
+                "shape": strip_angle_brackets(shape),
+                "constraint": strip_angle_brackets(pred),
+                "reason": "node-shape constraint not implemented; it was not evaluated",
+            }));
+        }
 
         for shape in &shapes {
             let target_class = match shape.get("targetClass") {
@@ -538,6 +617,18 @@ impl ShaclValidator {
             }
         }
 
+        // A validator has three answers, not two. `true` means every constraint
+        // ran and none failed, `false` means one failed, and null means the
+        // question could not be answered. Every path that can select nothing
+        // or execute nothing has to reach the third answer: a target that
+        // selects nothing lands in `nothing_matched`, a target form that is
+        // not implemented lands in `skipped`, and a constraint that cannot
+        // execute lands in `skipped` whether it sits on a property shape or on
+        // the node shape itself. A construct added later that is neither
+        // evaluated nor routed to one of those is the false clean this module
+        // exists to prevent; the reachability test in tests/shacl_test.rs is
+        // where it should fail.
+        //
         // A shapes graph that declared shapes we could not discover must not be
         // reported as a pass. `shapes.is_empty()` used to fall through to
         // `conforms: violations.is_empty()`, which is `true` for an empty run.

--- a/tests/shacl_test.rs
+++ b/tests/shacl_test.rs
@@ -333,3 +333,282 @@ fn test_target_class_still_works() {
     assert_eq!(v["conforms"], serde_json::Value::Bool(false), "report: {v}");
     assert_eq!(v["violation_count"], 1, "report: {v}");
 }
+
+// Regression tests for the node-shape gap (issue #108). The unimplemented
+// constraint check above reached one sh:property hop below the shape and no
+// further, so a constraint asserted on the node shape itself was never
+// evaluated and never recorded: `sh:closed true` over data carrying an
+// undeclared predicate returned `conforms: true`.
+
+const SH_NS: &str = "http://www.w3.org/ns/shacl#";
+
+fn skipped_names(v: &serde_json::Value, shape: &str, constraint: &str) -> bool {
+    v["skipped_constraints"].as_array().is_some_and(|a| {
+        a.iter()
+            .any(|e| e["shape"] == shape && e["constraint"] == constraint)
+    })
+}
+
+#[test]
+fn test_node_shape_constraints_reach_the_tri_state_verdict() {
+    // sh:closed, a node-level sh:not and sh:nodeKind are not implemented. Each
+    // must be recorded as skipped under its own IRI, and the verdict must be
+    // null, not a pass. Data: ex:a carries ex:mech, undeclared by any shape.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        ("sh:closed true", "closed"),
+        (
+            "sh:not [ sh:property [ sh:path ex:mech ; sh:hasValue ex:bad ] ]",
+            "not",
+        ),
+        ("sh:nodeKind sh:IRI", "nodeKind"),
+    ];
+    for (constraint_ttl, local) in cases {
+        let shapes = format!(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; {constraint_ttl} .
+        "#
+        );
+        let report = ShaclValidator::validate(&store, &shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            v["conforms"].is_null(),
+            "{local}: must not claim a pass: {v}"
+        );
+        assert!(
+            skipped_names(&v, "http://example.org/S", &format!("{SH_NS}{local}")),
+            "{local}: must be recorded as skipped on ex:S: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_tri_state_verdict_is_reachable_from_node_shape_property_shape_and_target() {
+    // A validator has three answers, not two, and every path that can select
+    // nothing or execute nothing has to reach the third one. This pins that
+    // the null verdict is reachable from each of the three places a SHACL
+    // construct can sit, each with its own skipped entry naming the construct,
+    // so the next construct added has somewhere obvious to fail.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        (
+            "node shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; sh:closed true .
+            "#,
+            format!("{SH_NS}closed"),
+        ),
+        (
+            "property shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+                sh:property [ sh:path ex:mech ; sh:not [ sh:hasValue ex:bad ] ] .
+            "#,
+            format!("{SH_NS}not"),
+        ),
+        (
+            "target",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetNode ex:a ;
+                sh:property [ sh:path ex:mech ; sh:minCount 1 ] .
+            "#,
+            "sh:targetNode".to_string(),
+        ),
+    ];
+    for (place, shapes, construct) in cases {
+        let report = ShaclValidator::validate(&store, shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            v["conforms"].is_null(),
+            "{place}: must not claim a pass: {v}"
+        );
+        assert!(
+            skipped_names(&v, "http://example.org/S", &construct),
+            "{place}: skipped entry must name {construct}: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_node_shape_annotations_and_class_axioms_keep_a_boolean_verdict() {
+    // The node-shape complement must not mistake what it does read for a
+    // constraint. Annotation predicates on an explicit shape, and the class's
+    // own axioms on an implicit class target (which carries rdfs:subClassOf,
+    // rdfs:label and rdfs:comment on the same subject), leave the verdict
+    // boolean and the skipped list absent.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing .");
+    let cases = [
+        (
+            "annotated explicit shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+                sh:name "Thing shape" ; sh:description "Every thing has a p." ;
+                sh:severity sh:Warning ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#,
+        ),
+        (
+            "implicit class target with class axioms",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix ex: <http://example.org/> .
+            ex:Thing a sh:NodeShape, rdfs:Class ;
+                rdfs:label "Thing" ; rdfs:comment "A thing." ;
+                rdfs:subClassOf ex:Top ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#,
+        ),
+    ];
+    for (case, shapes) in cases {
+        let report = ShaclValidator::validate(&store, shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(v["conforms"], serde_json::Value::Bool(false), "{case}: {v}");
+        assert_eq!(v["violation_count"], 1, "{case}: {v}");
+        assert!(
+            v.get("skipped_constraints").is_none(),
+            "{case}: nothing here is a constraint to skip: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_deactivated_shape_is_recorded_as_skipped() {
+    // SHACL says a deactivated shape must not be evaluated. This validator
+    // still evaluates it, so `sh:deactivated` is not implemented and must land
+    // in skipped rather than be whitelisted as if it were honoured.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; sh:deactivated true ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(v["conforms"].is_null(), "must not claim a verdict: {v}");
+    assert!(
+        skipped_names(&v, "http://example.org/S", &format!("{SH_NS}deactivated")),
+        "sh:deactivated must be recorded as skipped: {v}"
+    );
+}
+
+#[test]
+fn test_blank_node_shape_is_bound_as_itself_not_as_a_wildcard() {
+    // A shape written `[] a sh:NodeShape` is a blank node, and a blank-node
+    // label spliced into a SPARQL query is a non-distinguished variable, not
+    // a name. A node complement built by splicing the shape term enumerated
+    // every predicate in the shapes graph, routed the property shape's own
+    // sh:path and sh:minCount to skipped, and turned a boolean verdict into
+    // null. The shape must be bound as itself: a blank-node shape carrying
+    // only property constraints keeps its boolean verdict, and one carrying
+    // sh:closed still reaches skipped under its own label.
+    let store = store_with(NOT_DATA);
+    let property_only = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        [] a sh:NodeShape ; sh:targetClass ex:Thing ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+    "#;
+    let report = ShaclValidator::validate(&store, property_only).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        v["conforms"],
+        serde_json::Value::Bool(false),
+        "property only: {v}"
+    );
+    assert_eq!(v["violation_count"], 1, "property only: {v}");
+    assert!(
+        v.get("skipped_constraints").is_none(),
+        "property only: nothing here is a constraint to skip: {v}"
+    );
+
+    let closed = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        [] a sh:NodeShape ; sh:targetClass ex:Thing ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, closed).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(
+        v["conforms"].is_null(),
+        "closed: must not claim a pass: {v}"
+    );
+    let entries: Vec<&serde_json::Value> = v["skipped_constraints"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|e| e["constraint"] == format!("{SH_NS}closed"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(entries.len(), 1, "closed: exactly one entry: {v}");
+    assert!(
+        entries[0]["shape"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("_:")),
+        "closed: the entry names the blank-node shape: {v}"
+    );
+}
+
+#[test]
+fn test_node_constraint_is_recorded_once_however_many_target_classes() {
+    // Shape discovery yields one row per target class. A node constraint
+    // belongs to the shape, not to the pair, so a shape with two target
+    // classes reports its sh:closed once, not once per class.
+    let store =
+        store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing . ex:c a ex:Other .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing, ex:Other ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(v["conforms"].is_null(), "must not claim a pass: {v}");
+    let closed_entries = v["skipped_constraints"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|e| {
+                    e["shape"] == "http://example.org/S"
+                        && e["constraint"] == format!("{SH_NS}closed")
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(closed_entries, 1, "sh:closed recorded once: {v}");
+}
+
+#[test]
+fn test_node_constraint_on_a_shape_without_target_is_not_a_gap() {
+    // A node shape with no target selects no focus nodes under SHACL, so its
+    // constraints not running is what the specification asks for, not a
+    // gap. Its sh:closed must not be recorded as skipped, or every shapes
+    // graph carrying an unreferenced helper shape would read undetermined.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing ; ex:p ex:x .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+        ex:Helper a sh:NodeShape ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(v["conforms"], serde_json::Value::Bool(true), "report: {v}");
+    assert!(
+        v.get("skipped_constraints").is_none(),
+        "a targetless shape has nothing to evaluate: {v}"
+    );
+}


### PR DESCRIPTION
Fixes the `sh:closed` half of #108, ahead of the snapshot work as asked.

## What was wrong

The check added in 5e5fc91 routes unimplemented constraints to `skipped_constraints` and suppresses the verdict, but it reached one `sh:property` hop below the shape and no further: shape discovery projects only the shape and its target class, and both per-shape queries go through `sh:property`, so a constraint asserted on the `sh:NodeShape` subject itself never bound the predicate the complement inspects. Measured on main:

| shape carries | `conforms` | `skipped_constraints` |
| --- | --- | --- |
| `sh:not` on a property shape | `null` | 1 |
| `sh:not` on the node shape | **`true`** | 0 |
| `sh:closed true` on the node shape | **`true`** | 0 |
| `sh:nodeKind sh:IRI` on the node shape | **`true`** | 0 |

## What this does

A second complement query covers the shape node (`src/shacl.rs`). The whitelist is what the validator reads there, the four target forms (the three unimplemented ones are already recorded as skipped at the target check and are not counted twice), `sh:property` and `sh:sparql`, plus the annotation predicates (`sh:message`, `sh:severity`, `sh:name`, `sh:description`, `sh:order`, `sh:group`), which are never constraints. Anything else in the `sh:` namespace lands in `skipped_constraints` with its own reason and forces `conforms: null`, including a construct a later change starts to evaluate, since a whitelist that tracks what is implemented drifts the first time someone adds a constraint and forgets the list. `sh:deactivated` is deliberately among the skipped: SHACL says a deactivated shape must not be evaluated, this validator evaluates it, so the predicate is not honoured and must not read as if it were.

Two decisions worth your eye, both reversible in a line:

1. **The complement is restricted to the `sh:` namespace.** An implicit class target (a node that is both `sh:NodeShape` and `rdfs:Class` / `owl:Class`, accepted since 5e5fc91) carries the class's own axioms on the same subject, `rdfs:subClassOf`, `rdfs:label`, `owl:equivalentClass`; an unrestricted complement reported those as constraints and turned every such run undetermined (measured before adding the guard). A constraint is by definition a predicate in the `sh:` namespace; a predicate from any other namespace on a shape node is an annotation or an axiom. The cost: a non-`sh:` predicate on a node shape is never reported as skipped.
2. **The shape is bound as a variable and matched to the discovered shapes by its printed term, not spliced into the query text.** A shape written `[] a sh:NodeShape` prints as `_:label`, and a blank-node label inside a SPARQL query is a non-distinguished variable, not a name: the first cut of this PR spliced it, enumerated every predicate in the shapes graph, and turned a verdict that was a boolean on main into null for every anonymous shape. It runs once over `SELECT DISTINCT ?shape ?pred`, so a shape with two `sh:targetClass` values records its `sh:closed` once rather than once per target class. It stays restricted to discovered shapes, like the property complement: a shape with no target selects no focus nodes under SHACL, so its constraints not running is what the specification asks for.

The generalisation you asked for is written next to the verdict rather than in a commit message: a validator has three answers, not two, and every path that can select nothing or execute nothing has to reach the third one; `nothing_matched` for a target that selects nothing, `skipped` for a target form that is not implemented and for a constraint that cannot execute, at property level and at node level.

## Tests

`tests/shacl_test.rs`, seven new, all mutation-checked (each named mutation reddens exactly the tests that carry its claim, then the tree is restored):

- `test_tri_state_verdict_is_reachable_from_node_shape_property_shape_and_target`: the null verdict is reachable from the node shape (`sh:closed`), from a property shape (`sh:not`) and from a target (`sh:targetNode`), each with its own `skipped` entry naming the construct. Adding `sh:not` to the property whitelist or deleting the `sh:targetNode` target check reddens it.
- `test_node_shape_constraints_reach_the_tri_state_verdict`: `sh:closed`, node-level `sh:not` and `sh:nodeKind` each land in `skipped` under their own IRI. Disabling the node complement reddens it.
- `test_node_shape_annotations_and_class_axioms_keep_a_boolean_verdict`: annotations on an explicit shape and class axioms on an implicit class target keep a boolean verdict and no `skipped_constraints` key. Dropping the namespace guard reddens the implicit-class case; dropping `sh:name` from the whitelist reddens the explicit one.
- `test_deactivated_shape_is_recorded_as_skipped`: whitelisting `sh:deactivated` reddens it.
- `test_blank_node_shape_is_bound_as_itself_not_as_a_wildcard`, `test_node_constraint_is_recorded_once_however_many_target_classes`, `test_node_constraint_on_a_shape_without_target_is_not_a_gap`: the three consequences of decision 2.

Full default suite in a clean target directory: 74 binaries, 0 failures (`shacl_test` 19). `clippy --all-targets -D warnings` clean apart from `collapsible_else_if` at `src/main.rs:867`, which clippy 1.93 raises on main itself since fccfeb4; left alone. `rustfmt --check` reports the same pre-existing hunks on `src/shacl.rs` and `tests/shacl_test.rs` as on main, none in the added lines, and I did not reformat the files.

Not touched, on purpose: `check_shapes`, which is the other half of #108 and its own PR; and the inherited duplication of the property complement per discovery row, which predates this change.
