### PR TITLE
fix(shacl): onto_shacl_check reads declarations from every graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **`onto_shacl_check` reported a class or property declared inside a named
+  graph as missing.** The three existence lookups behind `missing_target_class`,
+  `missing_class_constraint` and `missing_path` ran a bare triple pattern, whose
+  default dataset is the default graph only, so an ontology loaded from TriG or
+  N-Quads, where every declaration sits in a `GRAPH` block, produced one issue
+  per referenced term while the same data in Turtle produced none. A declaration
+  is a declaration wherever it lives: the lookups now read the union of the
+  default graph and every named graph, unconditionally, with no scope argument
+  and no new response key. A class declared in no graph at all is still flagged
+  (#108).
 - **A daemon started with `[http] token` in config rejected every command it was
   meant to serve.** `serve-http` falls back to the config token and then enforces
   bearer auth, but `daemon start` recorded `token: null` in `daemon.json`

--- a/src/shacl.rs
+++ b/src/shacl.rs
@@ -813,11 +813,22 @@ fn graph_sparql_select(
     Ok(rows)
 }
 
-/// Check whether `iri` is declared as `owl:Class` or `rdfs:Class` in the graph.
+/// Check whether `iri` is declared as `owl:Class` or `rdfs:Class` anywhere in
+/// the store.
+///
+/// A declaration is a declaration wherever it lives. The bare pattern only
+/// sees the default graph, so an ontology loaded from TriG or N-Quads, whose
+/// declarations sit inside a `GRAPH` block, looked undeclared and every
+/// shape that referenced it was reported as `missing_target_class` or
+/// `missing_class_constraint`. The lookup therefore reads the union of the
+/// default graph and every named graph, unconditionally: there is no scope
+/// argument and no flag that narrows it back to the default graph.
 fn class_exists(graph: &Arc<GraphStore>, iri: &str) -> anyhow::Result<bool> {
     let query = format!(
         r#"SELECT ?x WHERE {{
-            <{iri}> a ?type .
+            {{ <{iri}> a ?type }}
+            UNION
+            {{ GRAPH ?g {{ <{iri}> a ?type }} }}
             FILTER(?type = <http://www.w3.org/2002/07/owl#Class>
                 || ?type = <http://www.w3.org/2000/01/rdf-schema#Class>)
         }} LIMIT 1"#
@@ -827,11 +838,17 @@ fn class_exists(graph: &Arc<GraphStore>, iri: &str) -> anyhow::Result<bool> {
 }
 
 /// Check whether `iri` is declared as an `owl:ObjectProperty`,
-/// `owl:DatatypeProperty`, or `rdf:Property` in the graph.
+/// `owl:DatatypeProperty`, or `rdf:Property` anywhere in the store.
+///
+/// Same rule as `class_exists`: the union of the default graph and every
+/// named graph, unconditionally, so a property declared inside a `GRAPH`
+/// block is not reported as `missing_path`.
 fn property_exists(graph: &Arc<GraphStore>, iri: &str) -> anyhow::Result<bool> {
     let query = format!(
         r#"SELECT ?x WHERE {{
-            <{iri}> a ?type .
+            {{ <{iri}> a ?type }}
+            UNION
+            {{ GRAPH ?g {{ <{iri}> a ?type }} }}
             FILTER(?type = <http://www.w3.org/2002/07/owl#ObjectProperty>
                 || ?type = <http://www.w3.org/2002/07/owl#DatatypeProperty>
                 || ?type = <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property>)

--- a/tests/shacl_check_test.rs
+++ b/tests/shacl_check_test.rs
@@ -7,6 +7,7 @@
 
 use open_ontologies::graph::GraphStore;
 use open_ontologies::shacl::ShaclValidator;
+use oxigraph::io::RdfFormat;
 use std::sync::Arc;
 
 const ONTOLOGY: &str = r#"
@@ -24,9 +25,36 @@ const ONTOLOGY: &str = r#"
                 rdfs:range  ex:Address .
 "#;
 
+/// The same declarations as `ONTOLOGY`, but inside a named graph. This is
+/// what a TriG or N-Quads ontology looks like once `load_content` has loaded
+/// it verbatim: nothing sits in the default graph (issue #108).
+const ONTOLOGY_TRIG: &str = r#"
+    @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix ex:   <http://example.org/> .
+
+    ex:schema {
+        ex:Person   a owl:Class .
+        ex:Address  a owl:Class .
+        ex:hasName  a owl:DatatypeProperty ;
+                    rdfs:domain ex:Person ;
+                    rdfs:range  <http://www.w3.org/2001/XMLSchema#string> .
+        ex:livesAt  a owl:ObjectProperty ;
+                    rdfs:domain ex:Person ;
+                    rdfs:range  ex:Address .
+    }
+"#;
+
 fn loaded() -> Arc<GraphStore> {
     let g = Arc::new(GraphStore::new());
     g.load_turtle(ONTOLOGY, None).expect("load ontology");
+    g
+}
+
+fn loaded_trig(dataset: &str) -> Arc<GraphStore> {
+    let g = Arc::new(GraphStore::new());
+    g.load_content(dataset, RdfFormat::TriG)
+        .expect("load TriG ontology");
     g
 }
 
@@ -226,4 +254,147 @@ fn well_formed_shapes_carry_per_shape_diagnostic_detail() {
     assert_eq!(pc.len(), 1);
     assert!(pc[0]["path_exists"].as_bool().unwrap());
     assert!(pc[0]["datatype_recognised"].as_bool().unwrap());
+}
+
+#[test]
+fn declarations_in_a_named_graph_are_seen_by_check_shapes() {
+    // Issue #108: the lookups used a bare triple pattern, whose default
+    // dataset is the default graph only, so an ontology loaded from TriG
+    // reported every class and property it declares as missing.
+    let graph = loaded_trig(ONTOLOGY_TRIG);
+
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+
+        ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:hasName ;
+                sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+            ] ;
+            sh:property [
+                sh:path ex:livesAt ;
+                sh:class ex:Address ;
+            ] .
+    "#;
+
+    let report_str = ShaclValidator::check_shapes(&graph, shapes).expect("check_shapes");
+    let report: serde_json::Value = serde_json::from_str(&report_str).expect("json");
+
+    assert!(
+        report["ok"].as_bool().unwrap(),
+        "declarations in a named graph must count; got:\n{}",
+        report_str
+    );
+    assert!(report["parses"].as_bool().unwrap());
+    assert_eq!(report["issue_count"].as_u64().unwrap(), 0);
+    assert_eq!(report["shape_count"].as_u64().unwrap(), 1);
+
+    let s = &report["shapes"].as_array().unwrap()[0];
+    assert!(s["target_class_exists"].as_bool().unwrap());
+    let pc = s["property_constraints"].as_array().unwrap();
+    assert_eq!(pc.len(), 2);
+    for constraint in pc {
+        assert!(
+            constraint["path_exists"].as_bool().unwrap(),
+            "path declared in a named graph must exist: {constraint}"
+        );
+    }
+    let with_class = pc
+        .iter()
+        .find(|c| c["class_constraint"].is_string())
+        .expect("one property carries sh:class");
+    assert!(with_class["class_constraint_exists"].as_bool().unwrap());
+}
+
+#[test]
+fn declarations_split_across_graphs_are_all_seen_by_check_shapes() {
+    // The target class lives in one named graph, the properties in another,
+    // and the sh:class target in the default graph. The lookup reads the
+    // union of all of them, so no issue is raised from any side.
+    let dataset = r#"
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix ex:  <http://example.org/> .
+
+        ex:classes { ex:Person a owl:Class . }
+
+        ex:properties {
+            ex:hasName a owl:DatatypeProperty .
+            ex:livesAt a owl:ObjectProperty .
+        }
+
+        { ex:Address a owl:Class . }
+    "#;
+    let graph = loaded_trig(dataset);
+
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+
+        ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:hasName ;
+                sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+            ] ;
+            sh:property [
+                sh:path ex:livesAt ;
+                sh:class ex:Address ;
+            ] .
+    "#;
+
+    let report_str = ShaclValidator::check_shapes(&graph, shapes).expect("check_shapes");
+    let report: serde_json::Value = serde_json::from_str(&report_str).expect("json");
+
+    assert!(
+        report["ok"].as_bool().unwrap(),
+        "declarations split across graphs must all count; got:\n{}",
+        report_str
+    );
+    assert_eq!(report["issue_count"].as_u64().unwrap(), 0);
+    assert_eq!(report["shape_count"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn undeclared_target_class_is_still_flagged_when_ontology_is_in_a_named_graph() {
+    // The fix reads every graph; it is not a blanket "always exists". A class
+    // declared in no graph at all is still reported, and the declared ones
+    // beside it are not.
+    let graph = loaded_trig(ONTOLOGY_TRIG);
+
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+
+        ex:GhostShape a sh:NodeShape ;
+            sh:targetClass ex:DoesNotExist ;
+            sh:property [
+                sh:path ex:hasName ;
+            ] .
+    "#;
+
+    let report_str = ShaclValidator::check_shapes(&graph, shapes).expect("check_shapes");
+    let report: serde_json::Value = serde_json::from_str(&report_str).expect("json");
+
+    assert!(!report["ok"].as_bool().unwrap());
+    assert_eq!(
+        report["issue_count"].as_u64().unwrap(),
+        1,
+        "exactly the undeclared class is flagged; got:\n{}",
+        report_str
+    );
+    let issues = report["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().any(|i| {
+            i["kind"].as_str() == Some("missing_target_class")
+                && i["value"].as_str().unwrap_or("").contains("DoesNotExist")
+        }),
+        "expected a missing_target_class issue for ex:DoesNotExist; got: {:?}",
+        issues
+    );
+    let s = &report["shapes"].as_array().unwrap()[0];
+    assert!(!s["target_class_exists"].as_bool().unwrap());
+    let pc = s["property_constraints"].as_array().unwrap();
+    assert!(pc[0]["path_exists"].as_bool().unwrap());
 }


### PR DESCRIPTION
The `onto_shacl_check` half of #108, split out ahead of the snapshot work as asked.

## What was wrong

`ShaclValidator::check_shapes` resolves `sh:targetClass`, `sh:class` and `sh:path` through `class_exists` and `property_exists` (`src/shacl.rs`), each a bare `<iri> a ?type` pattern run through `GraphStore::sparql_select`, whose default dataset is the store's default graph only. Declarations inside a `GRAPH` block (TriG or N-Quads input, loaded verbatim) were invisible, so a declared class one block away was reported as `missing_target_class`: the same two declarations gave `issue_count = 2` in a named graph and `0` in the default graph.

## What this does

Per your ruling, a declaration is a declaration wherever it lives: both lookups now read `{ <iri> a ?type } UNION { GRAPH ?g { <iri> a ?type } }`, unconditionally. No scope argument, no new response key, `FILTER` and `LIMIT 1` unchanged, `src/graph.rs` untouched. `class_exists` backs both `missing_target_class` and `missing_class_constraint`, and `property_exists` backs `missing_path`, so three issue kinds are corrected by two query edits.

## Tests

`tests/shacl_check_test.rs`, three new, each mutation-checked by reverting the `UNION` in one helper at a time (the class revert reddens the first two, the property revert reddens the `missing_path` half):

- `declarations_in_a_named_graph_are_seen_by_check_shapes`: the existing well-formed shapes against the same ontology written as TriG inside `ex:schema { … }`: `ok` true, `issue_count` 0, `target_class_exists`, `path_exists` and `class_constraint_exists` all true.
- `declarations_split_across_graphs_are_all_seen`: class in one named graph, property in another, the `sh:class` target in the default graph: still 0 issues.
- `undeclared_target_class_is_still_flagged_when_ontology_is_in_a_named_graph`: a class declared in no graph is still `missing_target_class`, so the fix is not a blanket "always exists".

Full default suite in a clean target directory: 74 binaries, 0 failures (`shacl_check_test` 10). `clippy --all-targets -D warnings` clean apart from `collapsible_else_if` at `src/main.rs:867`, which clippy 1.93 raises on main itself since fccfeb4; left alone. `rustfmt --check` reports only pre-existing hunks on the two files, none in the added lines.

Out of scope and worth knowing: `validate` itself is default-graph-only on the same mechanism (its nine `rdf:type/rdfs:subClassOf*` sites and `count_focus_nodes` all go through the bare select), so instance data in named graphs yields `focus_nodes: 0` and the `nothing_matched` null rather than a false pass. That is the snapshot question, sequenced behind #117 as you said.
