### PR TITLE
fix(shacl): node-shape constraints reach the tri-state verdict, and a false-valued control does not (continues #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ All notable changes to Open Ontologies are documented here.
   those are not constraints. A test now asserts the null verdict is reachable
   from the node shape, from a property shape and from a target, each naming
   its construct, so the next construct added has somewhere obvious to fail.
+  Two predicates are exempt at a false value and only at a false value:
+  `sh:closed false` is the SHACL default and restricts nothing, and
+  `sh:deactivated false` asks for the evaluation this validator performs, so
+  both are honoured in full and neither may suppress the verdict. A null on a
+  run where nothing went unevaluated is a false undetermined, and it costs
+  what the false clean costs, since a null that fires on a complete run
+  teaches the reader to ignore null. The value is read by value rather than by
+  lexical form, and a control whose value is not a boolean at all stays
+  skipped, because a value this validator cannot read is not one it can
+  honour (#108).
 - **`onto_shacl_check` reported a class or property declared inside a named
   graph as missing.** The three existence lookups behind `missing_target_class`,
   `missing_class_constraint` and `missing_path` ran a bare triple pattern, whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A constraint asserted on the node shape itself was never evaluated and
+  never reported, so `sh:closed true` over data carrying an undeclared
+  predicate returned `conforms: true`.** The check that routes unimplemented
+  constraints to `skipped_constraints` reached one `sh:property` hop below the
+  shape and no further: `sh:closed`, a node-level `sh:not`, `sh:nodeKind`,
+  `sh:and`, `sh:or`, `sh:xone`, `sh:in` and `sh:node` never bound the
+  predicate it inspects. A second complement now covers the shape node, with a
+  whitelist of the predicates the validator reads there (the target forms,
+  `sh:property`, `sh:sparql`) plus the annotation predicates, which are never
+  constraints, so any other `sh:` predicate lands in `skipped_constraints` and
+  the verdict becomes null. The shape is bound as a query variable and matched
+  to the discovered shape, not spliced into the query text: a shape written
+  `[] a sh:NodeShape` is a blank node, and a blank-node label inside a SPARQL
+  query is a wildcard, not a name. The complement runs once per shape rather
+  than once per target class, so a node constraint is recorded once.
+  `sh:deactivated` is among them on purpose: a deactivated shape is still
+  evaluated here, so the predicate is not honoured and must not read as if it
+  were. The complement is restricted to the `sh:` namespace, because an
+  implicit class target carries its own class axioms on the same subject and
+  those are not constraints. A test now asserts the null verdict is reachable
+  from the node shape, from a property shape and from a target, each naming
+  its construct, so the next construct added has somewhere obvious to fail.
 - **`onto_shacl_check` reported a class or property declared inside a named
   graph as missing.** The three existence lookups behind `missing_target_class`,
   `missing_class_constraint` and `missing_path` ran a bare triple pattern, whose

--- a/src/shacl.rs
+++ b/src/shacl.rs
@@ -2,7 +2,7 @@ use crate::graph::GraphStore;
 use oxigraph::io::{RdfFormat, RdfParser};
 use oxigraph::sparql::{QueryResults, SparqlEvaluator};
 use oxigraph::store::Store;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -15,8 +15,11 @@ use std::sync::Arc;
 ///
 /// Any constraint the validator cannot execute is recorded in
 /// `skipped_constraints` and suppresses the conformance verdict: `conforms`
-/// becomes null rather than true. Reporting success for rules that were never
-/// run is the one failure mode this validator must not have.
+/// becomes null rather than true. That holds wherever the constraint sits:
+/// on a property shape (`sh:not`), on the node shape itself (`sh:closed`,
+/// `sh:nodeKind`, `sh:deactivated`) or in a target form that is not selected
+/// (`sh:targetNode`). Reporting success for rules that were never run is the
+/// one failure mode this validator must not have.
 pub struct ShaclValidator;
 
 impl ShaclValidator {
@@ -85,6 +88,82 @@ impl ShaclValidator {
         }
         let mut unmatched: Vec<serde_json::Value> = Vec::new();
         let mut focus_nodes_total: u64 = 0;
+
+        // A constraint asserted on the node shape itself (`sh:closed`, a
+        // node-level `sh:not`, `sh:nodeKind`, `sh:and`, `sh:or`, `sh:xone`,
+        // `sh:in`, `sh:node`) never reaches the per-property complement in
+        // the loop below, which starts one sh:property hop under the shape.
+        // Before this complement existed, `sh:closed true` over data carrying
+        // an undeclared predicate returned `conforms: true`.
+        //
+        // It covers every discovered shape in one query, for two reasons.
+        // First, the shape is bound as a variable and matched to the
+        // discovery row by its printed term, not spliced into the query text:
+        // a shape written `[] a sh:NodeShape` prints as `_:label`, and a
+        // blank-node label inside a SPARQL query is a non-distinguished
+        // variable, not a name, so splicing it enumerated every predicate in
+        // the shapes graph and routed the property shape's own sh:path to
+        // skipped. Second, discovery yields one row per (shape, target class)
+        // and a node constraint belongs to the shape, so running the
+        // complement per row recorded `sh:closed` once per target class. It
+        // is restricted to discovered shapes, like the property complement:
+        // a shape using a target form this validator lacks is already
+        // recorded as skipped, and a shape with no target selects no focus
+        // nodes under SHACL, so its constraints not running is what the
+        // specification asks for, not a gap.
+        //
+        // The whitelist is the predicates the validator reads on the shape
+        // node (the four target forms, of which the three not implemented
+        // are already recorded as skipped above and must not be counted
+        // twice, sh:property and sh:sparql) plus the annotation predicates,
+        // which are never constraints. Any other sh: predicate lands in
+        // skipped, even one a later change starts to evaluate, because a
+        // whitelist that tracks what is implemented drifts the first time
+        // someone adds a constraint and forgets the list. `sh:deactivated` is
+        // deliberately absent: SHACL says a deactivated shape must not be
+        // evaluated and this validator evaluates it anyway, so the predicate
+        // is not implemented and must reach skipped like any other.
+        //
+        // The complement is restricted to the sh: namespace. A shape that is
+        // also an rdfs:Class or owl:Class (an implicit class target) carries
+        // the class's own axioms on the same subject (rdfs:subClassOf,
+        // rdfs:label, owl:equivalentClass), and an unrestricted complement
+        // would report those as constraints and turn every such run
+        // undetermined. A constraint is by definition a predicate in the sh:
+        // namespace; a predicate from any other namespace on a shape node is
+        // an annotation or an axiom, never a constraint.
+        let discovered: HashSet<&str> = shapes
+            .iter()
+            .filter_map(|s| s.get("shape").map(String::as_str))
+            .collect();
+        let unknown_on_node = query_solutions(
+            &shapes_store,
+            r#"
+            PREFIX sh: <http://www.w3.org/ns/shacl#>
+            SELECT DISTINCT ?shape ?pred WHERE {
+                ?shape a sh:NodeShape ; ?pred ?o .
+                FILTER(STRSTARTS(STR(?pred), "http://www.w3.org/ns/shacl#") && ?pred NOT IN (
+                    sh:targetClass, sh:targetNode, sh:targetSubjectsOf,
+                    sh:targetObjectsOf, sh:property, sh:sparql,
+                    sh:message, sh:severity, sh:name, sh:description,
+                    sh:order, sh:group
+                ))
+            }
+            "#,
+        )?;
+        for row in &unknown_on_node {
+            let (Some(shape), Some(pred)) = (row.get("shape"), row.get("pred")) else {
+                continue;
+            };
+            if !discovered.contains(shape.as_str()) {
+                continue;
+            }
+            skipped.push(serde_json::json!({
+                "shape": strip_angle_brackets(shape),
+                "constraint": strip_angle_brackets(pred),
+                "reason": "node-shape constraint not implemented; it was not evaluated",
+            }));
+        }
 
         for shape in &shapes {
             let target_class = match shape.get("targetClass") {
@@ -538,6 +617,18 @@ impl ShaclValidator {
             }
         }
 
+        // A validator has three answers, not two. `true` means every constraint
+        // ran and none failed, `false` means one failed, and null means the
+        // question could not be answered. Every path that can select nothing
+        // or execute nothing has to reach the third answer: a target that
+        // selects nothing lands in `nothing_matched`, a target form that is
+        // not implemented lands in `skipped`, and a constraint that cannot
+        // execute lands in `skipped` whether it sits on a property shape or on
+        // the node shape itself. A construct added later that is neither
+        // evaluated nor routed to one of those is the false clean this module
+        // exists to prevent; the reachability test in tests/shacl_test.rs is
+        // where it should fail.
+        //
         // A shapes graph that declared shapes we could not discover must not be
         // reported as a pass. `shapes.is_empty()` used to fall through to
         // `conforms: violations.is_empty()`, which is `true` for an empty run.

--- a/src/shacl.rs
+++ b/src/shacl.rs
@@ -124,6 +124,42 @@ impl ShaclValidator {
         // evaluated and this validator evaluates it anyway, so the predicate
         // is not implemented and must reach skipped like any other.
         //
+        // Two predicates are exempt at a FALSE value, and only at a false
+        // value, because at that value there is nothing left to implement.
+        // `sh:closed false` is the SHACL default and imposes no closed-shape
+        // restriction; `sh:deactivated false` says evaluate this shape, which
+        // is exactly what this validator does. Both are honoured in full, so
+        // recording them suppresses the verdict on a run in which nothing was
+        // missed. That is a false undetermined, and it costs as much as the
+        // false clean this complement exists to prevent: a null that fires on
+        // a complete run teaches the reader to ignore null, which destroys
+        // the signal the third answer carries. The value is read by value and
+        // not by lexical form, so "0"^^xsd:boolean is false like any other
+        // spelling. `sh:deactivated true` is unaffected and still reaches
+        // skipped, for the reason above.
+        //
+        // The isLiteral/datatype pair in front of the equality is defensive
+        // and, measured on this evaluator, changes no answer today: oxigraph
+        // answers `"false"^^xsd:string = false` with false, so an unreadable
+        // control stays skipped with or without it. It is kept because SPARQL
+        // 1.1 does not require that. RDFterm-equal is a type error on two
+        // literals that are neither the same term nor comparable, an error
+        // inside FILTER drops the solution rather than failing loudly, and a
+        // dropped solution here means a control this validator cannot read
+        // never reaches skipped: the false clean, arriving through the one
+        // code path written to prevent it, on an evaluator upgrade nobody
+        // would think to test for. Testing isLiteral, then the datatype, then
+        // the equality keeps every operand of the conjunction false rather
+        // than errored, on any evaluator. Being unmutatable is the point of
+        // it, so do not delete it for want of a reddening test.
+        //
+        // `sh:ignoredProperties` is knowingly not exempt and is not
+        // whitelisted. It modifies `sh:closed` rather than constraining
+        // anything by itself, so wherever it has an effect the shape also
+        // carries `sh:closed true`, which is recorded here and suppresses the
+        // verdict anyway. Carrying it without that is a shape that asks for
+        // nothing, and reporting it costs a report nobody is reading.
+        //
         // The complement is restricted to the sh: namespace. A shape that is
         // also an rdfs:Class or owl:Class (an implicit class target) carries
         // the class's own axioms on the same subject (rdfs:subClassOf,
@@ -140,6 +176,7 @@ impl ShaclValidator {
             &shapes_store,
             r#"
             PREFIX sh: <http://www.w3.org/ns/shacl#>
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             SELECT DISTINCT ?shape ?pred WHERE {
                 ?shape a sh:NodeShape ; ?pred ?o .
                 FILTER(STRSTARTS(STR(?pred), "http://www.w3.org/ns/shacl#") && ?pred NOT IN (
@@ -147,6 +184,8 @@ impl ShaclValidator {
                     sh:targetObjectsOf, sh:property, sh:sparql,
                     sh:message, sh:severity, sh:name, sh:description,
                     sh:order, sh:group
+                ) && !(?pred IN (sh:closed, sh:deactivated)
+                    && isLiteral(?o) && datatype(?o) = xsd:boolean && ?o = false
                 ))
             }
             "#,

--- a/tests/shacl_test.rs
+++ b/tests/shacl_test.rs
@@ -612,3 +612,128 @@ fn test_node_constraint_on_a_shape_without_target_is_not_a_gap() {
         "a targetless shape has nothing to evaluate: {v}"
     );
 }
+
+#[test]
+fn test_false_valued_controls_keep_a_boolean_verdict() {
+    // `sh:closed false` is the SHACL default and restricts nothing;
+    // `sh:deactivated false` says evaluate this shape, which this validator
+    // does. Both are honoured in full, so neither is a constraint that was
+    // missed and neither may suppress the verdict. A null verdict on a run
+    // where nothing went unevaluated is a false undetermined, and it costs
+    // the same as the false clean the complement exists to prevent.
+    //
+    // The value is read by value, not by lexical form, so "0"^^xsd:boolean is
+    // the same false as `false`. Reverting the guard to the name-only filter
+    // reddens every case here.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        (
+            "canonical false",
+            r#"sh:closed false ; sh:deactivated false"#,
+        ),
+        (
+            "alternative lexical form",
+            r#"sh:closed "0"^^<http://www.w3.org/2001/XMLSchema#boolean>"#,
+        ),
+    ];
+    for (case, controls) in cases {
+        let shapes = format!(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; {controls} ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#
+        );
+        let report = ShaclValidator::validate(&store, &shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(v["conforms"], serde_json::Value::Bool(false), "{case}: {v}");
+        assert_eq!(v["violation_count"], 1, "{case}: {v}");
+        assert!(
+            v.get("skipped_constraints").is_none(),
+            "{case}: a false control was honoured, not skipped: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_a_control_this_validator_cannot_read_stays_skipped() {
+    // The exemption is for a false BOOLEAN, not for the predicate. A value
+    // that is a plain string, or not a literal at all, is a value this
+    // validator cannot read and therefore cannot honour, so it must stay in
+    // skipped and suppress the verdict.
+    //
+    // Reverting the exemption to a name-only filter leaves this test green,
+    // and that is correct: it pins the boundary of the exemption, not the
+    // exemption itself. Dropping the isLiteral/datatype guard in front of the
+    // equality also leaves it green, which was measured rather than assumed.
+    // Oxigraph answers `"false"^^xsd:string = false` with false instead of
+    // the type error SPARQL 1.1 allows, so the guard changes no answer on
+    // this evaluator and cannot be mutation-covered here. The reason it stays
+    // in the query is in the comment beside it: on an evaluator that does
+    // raise, the error would propagate out of the FILTER, drop the solution
+    // and silently stop skipping the controls this test is about.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        ("plain string", r#""false""#, "closed"),
+        (
+            "typed as a string",
+            r#""false"^^<http://www.w3.org/2001/XMLSchema#string>"#,
+            "closed",
+        ),
+        (
+            "an IRI, not a literal",
+            "<http://example.org/Maybe>",
+            "closed",
+        ),
+        ("deactivated as a string", r#""false""#, "deactivated"),
+    ];
+    for (case, value, predicate) in cases {
+        let shapes = format!(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; sh:{predicate} {value} ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#
+        );
+        let report = ShaclValidator::validate(&store, &shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            v["conforms"].is_null(),
+            "{case}: must not claim a verdict: {v}"
+        );
+        assert!(
+            skipped_names(&v, "http://example.org/S", &format!("{SH_NS}{predicate}")),
+            "{case}: an unreadable control must stay skipped: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_a_true_control_is_still_skipped_beside_a_false_one() {
+    // The exemption is per value, not per shape and not per predicate. A
+    // shape carrying `sh:closed true` and `sh:deactivated false` has one
+    // construct that was not evaluated and one that was honoured, and the
+    // report must say exactly that: sh:closed skipped, sh:deactivated absent,
+    // verdict null. Exempting the predicate rather than the value reddens it.
+    let store = store_with(NOT_DATA);
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+            sh:closed true ; sh:deactivated false ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(v["conforms"].is_null(), "sh:closed true was not run: {v}");
+    assert!(
+        skipped_names(&v, "http://example.org/S", &format!("{SH_NS}closed")),
+        "sh:closed true must be recorded: {v}"
+    );
+    assert!(
+        !skipped_names(&v, "http://example.org/S", &format!("{SH_NS}deactivated")),
+        "sh:deactivated false was honoured and must not be recorded: {v}"
+    );
+}

--- a/tests/shacl_test.rs
+++ b/tests/shacl_test.rs
@@ -333,3 +333,282 @@ fn test_target_class_still_works() {
     assert_eq!(v["conforms"], serde_json::Value::Bool(false), "report: {v}");
     assert_eq!(v["violation_count"], 1, "report: {v}");
 }
+
+// Regression tests for the node-shape gap (issue #108). The unimplemented
+// constraint check above reached one sh:property hop below the shape and no
+// further, so a constraint asserted on the node shape itself was never
+// evaluated and never recorded: `sh:closed true` over data carrying an
+// undeclared predicate returned `conforms: true`.
+
+const SH_NS: &str = "http://www.w3.org/ns/shacl#";
+
+fn skipped_names(v: &serde_json::Value, shape: &str, constraint: &str) -> bool {
+    v["skipped_constraints"].as_array().is_some_and(|a| {
+        a.iter()
+            .any(|e| e["shape"] == shape && e["constraint"] == constraint)
+    })
+}
+
+#[test]
+fn test_node_shape_constraints_reach_the_tri_state_verdict() {
+    // sh:closed, a node-level sh:not and sh:nodeKind are not implemented. Each
+    // must be recorded as skipped under its own IRI, and the verdict must be
+    // null, not a pass. Data: ex:a carries ex:mech, undeclared by any shape.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        ("sh:closed true", "closed"),
+        (
+            "sh:not [ sh:property [ sh:path ex:mech ; sh:hasValue ex:bad ] ]",
+            "not",
+        ),
+        ("sh:nodeKind sh:IRI", "nodeKind"),
+    ];
+    for (constraint_ttl, local) in cases {
+        let shapes = format!(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; {constraint_ttl} .
+        "#
+        );
+        let report = ShaclValidator::validate(&store, &shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            v["conforms"].is_null(),
+            "{local}: must not claim a pass: {v}"
+        );
+        assert!(
+            skipped_names(&v, "http://example.org/S", &format!("{SH_NS}{local}")),
+            "{local}: must be recorded as skipped on ex:S: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_tri_state_verdict_is_reachable_from_node_shape_property_shape_and_target() {
+    // A validator has three answers, not two, and every path that can select
+    // nothing or execute nothing has to reach the third one. This pins that
+    // the null verdict is reachable from each of the three places a SHACL
+    // construct can sit, each with its own skipped entry naming the construct,
+    // so the next construct added has somewhere obvious to fail.
+    let store = store_with(NOT_DATA);
+    let cases = [
+        (
+            "node shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; sh:closed true .
+            "#,
+            format!("{SH_NS}closed"),
+        ),
+        (
+            "property shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+                sh:property [ sh:path ex:mech ; sh:not [ sh:hasValue ex:bad ] ] .
+            "#,
+            format!("{SH_NS}not"),
+        ),
+        (
+            "target",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetNode ex:a ;
+                sh:property [ sh:path ex:mech ; sh:minCount 1 ] .
+            "#,
+            "sh:targetNode".to_string(),
+        ),
+    ];
+    for (place, shapes, construct) in cases {
+        let report = ShaclValidator::validate(&store, shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            v["conforms"].is_null(),
+            "{place}: must not claim a pass: {v}"
+        );
+        assert!(
+            skipped_names(&v, "http://example.org/S", &construct),
+            "{place}: skipped entry must name {construct}: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_node_shape_annotations_and_class_axioms_keep_a_boolean_verdict() {
+    // The node-shape complement must not mistake what it does read for a
+    // constraint. Annotation predicates on an explicit shape, and the class's
+    // own axioms on an implicit class target (which carries rdfs:subClassOf,
+    // rdfs:label and rdfs:comment on the same subject), leave the verdict
+    // boolean and the skipped list absent.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing .");
+    let cases = [
+        (
+            "annotated explicit shape",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+                sh:name "Thing shape" ; sh:description "Every thing has a p." ;
+                sh:severity sh:Warning ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#,
+        ),
+        (
+            "implicit class target with class axioms",
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix ex: <http://example.org/> .
+            ex:Thing a sh:NodeShape, rdfs:Class ;
+                rdfs:label "Thing" ; rdfs:comment "A thing." ;
+                rdfs:subClassOf ex:Top ;
+                sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+            "#,
+        ),
+    ];
+    for (case, shapes) in cases {
+        let report = ShaclValidator::validate(&store, shapes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(v["conforms"], serde_json::Value::Bool(false), "{case}: {v}");
+        assert_eq!(v["violation_count"], 1, "{case}: {v}");
+        assert!(
+            v.get("skipped_constraints").is_none(),
+            "{case}: nothing here is a constraint to skip: {v}"
+        );
+    }
+}
+
+#[test]
+fn test_deactivated_shape_is_recorded_as_skipped() {
+    // SHACL says a deactivated shape must not be evaluated. This validator
+    // still evaluates it, so `sh:deactivated` is not implemented and must land
+    // in skipped rather than be whitelisted as if it were honoured.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing ; sh:deactivated true ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(v["conforms"].is_null(), "must not claim a verdict: {v}");
+    assert!(
+        skipped_names(&v, "http://example.org/S", &format!("{SH_NS}deactivated")),
+        "sh:deactivated must be recorded as skipped: {v}"
+    );
+}
+
+#[test]
+fn test_blank_node_shape_is_bound_as_itself_not_as_a_wildcard() {
+    // A shape written `[] a sh:NodeShape` is a blank node, and a blank-node
+    // label spliced into a SPARQL query is a non-distinguished variable, not
+    // a name. A node complement built by splicing the shape term enumerated
+    // every predicate in the shapes graph, routed the property shape's own
+    // sh:path and sh:minCount to skipped, and turned a boolean verdict into
+    // null. The shape must be bound as itself: a blank-node shape carrying
+    // only property constraints keeps its boolean verdict, and one carrying
+    // sh:closed still reaches skipped under its own label.
+    let store = store_with(NOT_DATA);
+    let property_only = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        [] a sh:NodeShape ; sh:targetClass ex:Thing ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+    "#;
+    let report = ShaclValidator::validate(&store, property_only).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        v["conforms"],
+        serde_json::Value::Bool(false),
+        "property only: {v}"
+    );
+    assert_eq!(v["violation_count"], 1, "property only: {v}");
+    assert!(
+        v.get("skipped_constraints").is_none(),
+        "property only: nothing here is a constraint to skip: {v}"
+    );
+
+    let closed = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        [] a sh:NodeShape ; sh:targetClass ex:Thing ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, closed).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(
+        v["conforms"].is_null(),
+        "closed: must not claim a pass: {v}"
+    );
+    let entries: Vec<&serde_json::Value> = v["skipped_constraints"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|e| e["constraint"] == format!("{SH_NS}closed"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(entries.len(), 1, "closed: exactly one entry: {v}");
+    assert!(
+        entries[0]["shape"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("_:")),
+        "closed: the entry names the blank-node shape: {v}"
+    );
+}
+
+#[test]
+fn test_node_constraint_is_recorded_once_however_many_target_classes() {
+    // Shape discovery yields one row per target class. A node constraint
+    // belongs to the shape, not to the pair, so a shape with two target
+    // classes reports its sh:closed once, not once per class.
+    let store =
+        store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing . ex:c a ex:Other .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing, ex:Other ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert!(v["conforms"].is_null(), "must not claim a pass: {v}");
+    let closed_entries = v["skipped_constraints"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|e| {
+                    e["shape"] == "http://example.org/S"
+                        && e["constraint"] == format!("{SH_NS}closed")
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(closed_entries, 1, "sh:closed recorded once: {v}");
+}
+
+#[test]
+fn test_node_constraint_on_a_shape_without_target_is_not_a_gap() {
+    // A node shape with no target selects no focus nodes under SHACL, so its
+    // constraints not running is what the specification asks for, not a
+    // gap. Its sh:closed must not be recorded as skipped, or every shapes
+    // graph carrying an unreferenced helper shape would read undetermined.
+    let store = store_with("@prefix ex: <http://example.org/> . ex:b a ex:Thing ; ex:p ex:x .");
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Thing ;
+            sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+        ex:Helper a sh:NodeShape ; sh:closed true .
+    "#;
+    let report = ShaclValidator::validate(&store, shapes).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(v["conforms"], serde_json::Value::Bool(true), "report: {v}");
+    assert!(
+        v.get("skipped_constraints").is_none(),
+        "a targetless shape has nothing to evaluate: {v}"
+    );
+}


### PR DESCRIPTION
Lands #121 with the false-valued-controls fix on top, so the node-shape half of #108 goes in as one piece rather than waiting on a round trip.

@nicolas-geysse's commit is cherry-picked unmodified and keeps his authorship. The only conflict was one `CHANGELOG.md` hunk against #122, which I resolved by keeping both entries. Nothing in his implementation is changed.

## What the second commit adds

The complement query filtered on the predicate name alone. It bound `?o` and never read it, so `sh:closed false` and `sh:deactivated false` landed in `skipped_constraints` and forced `conforms: null` on a shapes graph where every constraint had in fact been evaluated. `sh:closed false` is the SHACL default and imposes no closed-shape restriction, and `sh:deactivated false` asks for the evaluation this validator performs, so both are honoured in full.

That is a false undetermined, and it costs what the false clean this complement exists to prevent costs. The verdict has three answers only while the third one means something. A null that fires on a complete run teaches the reader to ignore null, and the next real gap then reads as noise.

The exemption is per value, never per predicate and never per shape. `sh:closed true` beside `sh:deactivated false` records the first and not the second. The value is read by value rather than by lexical form, so `"0"^^xsd:boolean` is the same false as `false`. A control whose value is not a boolean at all stays in `skipped`, because a value this validator cannot read is not one it can honour.

`sh:ignoredProperties` is knowingly not exempt and not whitelisted. It modifies `sh:closed` rather than constraining anything itself, so wherever it has an effect the shape also carries `sh:closed true`, which is recorded and suppresses the verdict anyway.

## The guard that cannot be mutation-covered, and why it stays

The `isLiteral(?o) && datatype(?o) = xsd:boolean` pair in front of the equality changes no answer on this evaluator. I measured that rather than assuming it: with the pair removed, all four cases in `test_a_control_this_validator_cannot_read_stays_skipped` stay green, because oxigraph answers `"false"^^xsd:string = false` with false rather than the type error SPARQL 1.1 permits on RDFterm-equal.

I kept it, and documented it in place as deliberately unmutatable, because an error inside `FILTER` drops the solution rather than failing loudly. On an evaluator that does raise, the unguarded form would silently stop skipping exactly the controls it cannot read: the false clean, arriving through the one code path written to prevent it, on a dependency upgrade nobody would think to test for.

## Verification

- Full default suite in this working tree: **74 binaries, 757 tests, 0 failures** (`shacl_test` 22, `shacl_check_test` 10).
- **Mutation 1**, reverting the exemption to the name-only filter: `test_false_valued_controls_keep_a_boolean_verdict` and `test_a_true_control_is_still_skipped_beside_a_false_one` fail, nothing else does. Restored and re-run green.
- **Mutation 2**, dropping the isLiteral/datatype pair: nothing reddens, which is the measurement recorded above and the reason the code comment says so instead of claiming a test it does not have.
- `cargo clippy --all-targets` clean on both touched files.
- `rustfmt --check` reports **five** hunks on `tests/shacl_test.rs`, the same five it reports on `origin/main`, and the same count on `src/shacl.rs`. None fall in the added lines and neither file was reformatted.

Closes the node-shape half of #108. The `check_shapes` half landed as #122. What remains open there is the snapshot half: `validate` itself is still default-graph-only on the same mechanism, so instance data in named graphs yields `focus_nodes: 0` and a `nothing_matched` null rather than a false pass.

Co-authored-by: nicolas-geysse <nicolas-geysse@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
