### PR TITLE
fix: three more tools answered about the default graph alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Open Ontologies are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **Three more tools answered about the default graph alone, so their answers
+  depended on the serialisation the data arrived in.** Same defect as the two
+  halves of #108, found by loading identical content as Turtle and as TriG and
+  comparing the reports rather than by reading the code. `onto_vocab_check`
+  read zero declared terms from an ontology loaded as TriG or N-Quads and
+  bailed with a warning telling the caller to load an ontology they had already
+  loaded. `onto_communities` reported no communities and the note "no relations
+  between named subjects and objects", asserting a fact about the corpus it had
+  not checked. Shape induction counted no instances and returned an empty
+  lattice, indistinguishable from a class that genuinely has none. All three now
+  read the union of every graph. `tests/serialisation_invariance_test.rs` pins
+  the rule and names the modules still unmeasured, since roughly thirty run
+  internally authored SELECTs and only four have been checked (#108).
 - **`onto_shacl` validated the default graph and nothing else, so whether data
   was checked at all depended on the serialisation it arrived in.** Every
   data-side query ran through the store's default dataset specification, which

--- a/src/communities.rs
+++ b/src/communities.rs
@@ -280,7 +280,12 @@ impl Communities {
             FILTER(?p != <http://www.w3.org/2002/07/owl#disjointWith>) \
             FILTER(?p != <http://www.w3.org/2002/07/owl#equivalentClass>) \
         } LIMIT 20000";
-        let raw = self.graph.sparql_select(query)?;
+        // Every graph: which graph an entity relation sits in says nothing
+        // about whether it is a relation. Reading the default graph alone
+        // over a dataset serialisation reported zero communities and the
+        // note "no relations between named subjects and objects", which
+        // asserts a fact about the corpus that was not checked (#108).
+        let raw = self.graph.sparql_select_union(query)?;
         let parsed: serde_json::Value = serde_json::from_str(&raw)?;
         let rows = parsed
             .get("results")
@@ -302,7 +307,10 @@ impl Communities {
     /// rdfs:label per IRI, for skeletons a human can read.
     fn labels_of(&self, iris: &[String]) -> anyhow::Result<HashMap<String, String>> {
         let query = "SELECT ?s ?l WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?l } LIMIT 20000";
-        let raw = self.graph.sparql_select(query)?;
+        // Every graph, for the same reason as `edges`: a label in a named
+        // graph is still that entity's label, and a skeleton naming members
+        // by their URI local name where a label exists is a worse report.
+        let raw = self.graph.sparql_select_union(query)?;
         let parsed: serde_json::Value = serde_json::from_str(&raw)?;
         let wanted: BTreeSet<&str> = iris.iter().map(|s| s.as_str()).collect();
         let mut out = HashMap::new();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -231,6 +231,20 @@ impl GraphStore {
         })
     }
 
+    /// Run a SELECT over the store's default graph.
+    ///
+    /// **Which of the two you want depends on who wrote the query.** A query
+    /// someone typed belongs here: they chose the dataset by writing `GRAPH`
+    /// or not writing it, and widening it under them would change the meaning
+    /// of what they wrote. A query this codebase authored to ask a question
+    /// about the store belongs in [`Self::sparql_select_union`], because the
+    /// answer to "what does this store declare" or "which instances are
+    /// there" must not depend on the file format the triples arrived in.
+    ///
+    /// Getting that backwards does not look like a bug. It looks like a clean
+    /// report over a store that holds nothing, which is how it survived in
+    /// four separate tools at once (#108). `tests/serialisation_invariance_test.rs`
+    /// is where a tool's answer is pinned against both serialisations.
     pub fn sparql_select(&self, query: &str) -> anyhow::Result<String> {
         self.select_with_dataset(query, false)
     }

--- a/src/shape_combinatorics.rs
+++ b/src/shape_combinatorics.rs
@@ -65,7 +65,9 @@ pub fn enumerate(graph: &Arc<GraphStore>, class_iri: &str, max_size: usize) -> a
         "SELECT DISTINCT ?p WHERE {{ ?p <http://www.w3.org/2000/01/rdf-schema#domain> <{}> }} LIMIT 100",
         class_iri
     );
-    let js = graph.sparql_select(&q)?;
+    // Every graph: see `count_query`. A property is declared on the class
+    // wherever the declaration sits.
+    let js = graph.sparql_select_union(&q)?;
     let v: serde_json::Value = serde_json::from_str(&js)?;
     let rows = v["results"].as_array().cloned().unwrap_or_default();
     let mut props: Vec<String> = rows
@@ -207,8 +209,12 @@ pub fn induce_shapes(
     })
 }
 
+/// Reads every graph: the instances of a class are the store's instances,
+/// whichever graph they sit in. Over a dataset serialisation this counted
+/// zero and induction returned an empty lattice, indistinguishable from a
+/// class that genuinely has no instances (#108).
 fn count_query(graph: &Arc<GraphStore>, q: &str) -> anyhow::Result<u64> {
-    let js = graph.sparql_select(q)?;
+    let js = graph.sparql_select_union(q)?;
     let v: serde_json::Value = serde_json::from_str(&js).unwrap_or(serde_json::Value::Null);
     let n_str = v["results"][0]["n"].as_str().unwrap_or("0");
     // SPARQL aggregate values come as literal strings like

--- a/src/vocab_check.rs
+++ b/src/vocab_check.rs
@@ -64,8 +64,14 @@ fn strip_brackets(s: &str) -> &str {
 }
 
 /// Run a SELECT and collect the IRI values of one variable (literals/blanks skipped).
+///
+/// Reads every graph. The ontology's declared vocabulary is a fact about the
+/// store, not about one graph in it, and reading the default graph alone made
+/// an ontology loaded from TriG or N-Quads declare nothing: the check bailed
+/// with `ontology_terms: 0` and told the caller to load an ontology they had
+/// already loaded. See the graph-scope rule on issue #108.
 fn select_iris(graph: &Arc<GraphStore>, query: &str, var: &str) -> anyhow::Result<Vec<String>> {
-    let json_str = graph.sparql_select(query)?;
+    let json_str = graph.sparql_select_union(query)?;
     let parsed: serde_json::Value = serde_json::from_str(&json_str)?;
     let mut out = Vec::new();
     if let Some(rows) = parsed["results"].as_array() {

--- a/tests/serialisation_invariance_test.rs
+++ b/tests/serialisation_invariance_test.rs
@@ -1,0 +1,233 @@
+//! Does a tool answer the same question the same way when the identical
+//! triples arrive in a different serialisation?
+//!
+//! A tool that asks a question about the loaded store, rather than running a
+//! query someone wrote, has no business caring which file format the triples
+//! came from. Turtle and N-Triples put everything in the default graph; TriG
+//! and N-Quads put it wherever the document says. `GraphStore::sparql_select`
+//! leaves the evaluator on its default dataset specification, which is the
+//! default graph alone, so any tool built on it silently answers about a
+//! fraction of the store the moment a dataset serialisation is loaded.
+//!
+//! That failure mode does not look like a failure. It looks like a clean
+//! report over a store that holds nothing, which is why #108 sat open on two
+//! separate tools and neither arrived as a bug report. Each test here loads
+//! the same content twice, once as Turtle and once as TriG with every triple
+//! inside a named graph, and asserts the two answers agree.
+//!
+//! **A passing test here is worth only as much as its fixture.** Two tools
+//! answering "nothing" agree perfectly, so every comparison needs the Turtle
+//! side to have found something first. The first cut of the community test
+//! passed while proving nothing, because its fixture was schema triples and
+//! `edges()` deliberately excludes those. Where a positive assertion is
+//! cheap, it is written before the comparison.
+//!
+//! **What this file does not cover.** Roughly thirty modules run internally
+//! authored SELECTs through `sparql_select`. The four covered here were
+//! measured; the rest are unmeasured rather than known-good, and `enforce`,
+//! `drift`, `align`, `plan`, `support` and `structembed` are the ones most
+//! likely to be wrong in the same way. Add a case here before fixing one, so
+//! the fix is measured rather than assumed. The rule for which callers want
+//! which dataset is on `GraphStore::sparql_select`.
+
+use open_ontologies::graph::GraphStore;
+use oxigraph::io::RdfFormat;
+use std::sync::Arc;
+
+/// The same ontology, in the two shapes. `TRIG` wraps `TURTLE`'s statements in
+/// a single named graph and adds nothing else, so any difference in a tool's
+/// answer is the tool reading the default graph alone.
+const TURTLE: &str = r#"
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+ex:Building a owl:Class ; rdfs:label "Building" .
+ex:Bridge a owl:Class ; rdfs:subClassOf ex:Building .
+ex:height a owl:DatatypeProperty ; rdfs:domain ex:Building .
+ex:spans a owl:ObjectProperty ; rdfs:domain ex:Bridge ; rdfs:range ex:Building .
+"#;
+
+const TRIG: &str = r#"
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+ex:schema {
+    ex:Building a owl:Class ; rdfs:label "Building" .
+    ex:Bridge a owl:Class ; rdfs:subClassOf ex:Building .
+    ex:height a owl:DatatypeProperty ; rdfs:domain ex:Building .
+    ex:spans a owl:ObjectProperty ; rdfs:domain ex:Bridge ; rdfs:range ex:Building .
+}
+"#;
+
+fn turtle_store() -> Arc<GraphStore> {
+    let g = Arc::new(GraphStore::new());
+    g.load_turtle(TURTLE, None).expect("load Turtle");
+    g
+}
+
+fn trig_store() -> Arc<GraphStore> {
+    let g = Arc::new(GraphStore::new());
+    g.load_content(TRIG, RdfFormat::TriG).expect("load TriG");
+    g
+}
+
+/// Both stores hold the same triples. If this ever fails, every other test in
+/// the file is comparing two different things and its verdict means nothing.
+#[test]
+fn the_two_stores_hold_the_same_triples() {
+    assert_eq!(
+        turtle_store().triple_count(),
+        trig_store().triple_count(),
+        "the fixtures must differ only in which graph the triples sit in"
+    );
+}
+
+#[test]
+fn vocab_check_reads_declarations_from_every_graph() {
+    // The closed-world check that catches hallucinated terms in generated
+    // data. It builds the ontology's declared vocabulary with a bare pattern,
+    // so an ontology loaded from TriG declared nothing as far as the check was
+    // concerned.
+    //
+    // Measured rather than assumed, because the failure is not the one it
+    // looks like it should be: the check does not flag every term as
+    // hallucinated. It notices it has zero declared terms and bails with
+    // `conforms: false`, an empty `hallucinated_terms`, and a warning telling
+    // the caller to load an ontology first. So it is the loud member of this
+    // family, and still wrong in a way that costs more than it looks: the
+    // advice in the warning is to do the thing the caller has already done,
+    // which sends them looking at their input rather than at the tool.
+    let data = r#"
+        @prefix ex: <http://example.org/> .
+        ex:b1 a ex:Building ; ex:height "65" .
+    "#;
+    let from_turtle =
+        open_ontologies::vocab_check::check_data_vocab(&turtle_store(), data, &[]).expect("turtle");
+    let from_trig =
+        open_ontologies::vocab_check::check_data_vocab(&trig_store(), data, &[]).expect("trig");
+    let t: serde_json::Value = serde_json::from_str(&from_turtle).unwrap();
+    let q: serde_json::Value = serde_json::from_str(&from_trig).unwrap();
+    assert_eq!(
+        t, q,
+        "the same data against the same ontology must give the same report\nturtle: {t}\ntrig:   {q}"
+    );
+}
+
+#[test]
+fn shacl_validate_reads_instances_from_every_graph() {
+    // Already fixed, and pinned here so the fix is measured by the same rule
+    // as the rest rather than only by its own test.
+    let shapes = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:S a sh:NodeShape ; sh:targetClass ex:Building ;
+            sh:property [ sh:path ex:height ; sh:minCount 1 ] .
+    "#;
+    let instances = "@prefix ex: <http://example.org/> . ex:b1 a ex:Building .";
+    let turtle = turtle_store();
+    turtle.load_turtle(instances, None).unwrap();
+    let trig = trig_store();
+    trig.load_content(
+        "@prefix ex: <http://example.org/> . ex:data { ex:b1 a ex:Building . }",
+        RdfFormat::TriG,
+    )
+    .expect("load instances into a named graph");
+
+    let t: serde_json::Value = serde_json::from_str(
+        &open_ontologies::shacl::ShaclValidator::validate(&turtle, shapes).unwrap(),
+    )
+    .unwrap();
+    let q: serde_json::Value = serde_json::from_str(
+        &open_ontologies::shacl::ShaclValidator::validate(&trig, shapes).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(t["focus_nodes"], q["focus_nodes"], "turtle {t}\ntrig {q}");
+    assert_eq!(t["conforms"], q["conforms"], "turtle {t}\ntrig {q}");
+    assert_eq!(
+        t["violation_count"], q["violation_count"],
+        "turtle {t}\ntrig {q}"
+    );
+}
+
+#[test]
+fn community_detection_reads_every_graph() {
+    // Clusters the entity graph and reports a skeleton per community. Reading
+    // the default graph alone over a TriG store finds no entities and reports
+    // no communities, which reads as "this corpus has no structure" rather
+    // than as "nothing was looked at".
+    //
+    // The fixture is instance relations rather than the shared schema one,
+    // because `edges()` deliberately excludes rdf:type, rdfs:subClassOf,
+    // domain, range and the owl class axioms: it clusters the entity graph,
+    // not the schema. A schema-only fixture makes both sides empty and the
+    // comparison vacuous, which is how the first cut of this test passed
+    // while proving nothing.
+    let entities = "ex:b1 ex:spans ex:b2 . ex:b2 ex:spans ex:b3 . ex:b3 ex:spans ex:b1 .";
+    let turtle = Arc::new(GraphStore::new());
+    turtle
+        .load_turtle(
+            &format!("@prefix ex: <http://example.org/> . {entities}"),
+            None,
+        )
+        .unwrap();
+    let trig = Arc::new(GraphStore::new());
+    trig.load_content(
+        &format!("@prefix ex: <http://example.org/> . ex:data {{ {entities} }}"),
+        RdfFormat::TriG,
+    )
+    .unwrap();
+
+    let t: serde_json::Value = serde_json::from_str(
+        &open_ontologies::communities::Communities::new(turtle)
+            .detect(1, 5)
+            .expect("turtle"),
+    )
+    .unwrap();
+    let q: serde_json::Value = serde_json::from_str(
+        &open_ontologies::communities::Communities::new(trig)
+            .detect(1, 5)
+            .expect("trig"),
+    )
+    .unwrap();
+    assert!(
+        t["communities"].as_array().is_some_and(|a| !a.is_empty()),
+        "the Turtle side must find something, or this test proves nothing: {t}"
+    );
+    assert_eq!(
+        t["communities"], q["communities"],
+        "turtle: {t}\ntrig:   {q}"
+    );
+}
+
+#[test]
+fn shape_induction_reads_every_graph() {
+    // Induces shapes from the instances of a class. Over a TriG store it
+    // enumerated an empty lattice, which is indistinguishable from a class
+    // that genuinely has no instances.
+    let instances = "ex:b1 a ex:Building ; ex:height \"65\" .";
+    let turtle = turtle_store();
+    turtle
+        .load_turtle(
+            &format!("@prefix ex: <http://example.org/> . {instances}"),
+            None,
+        )
+        .unwrap();
+    let trig = trig_store();
+    trig.load_content(
+        &format!("@prefix ex: <http://example.org/> . ex:data {{ {instances} }}"),
+        RdfFormat::TriG,
+    )
+    .unwrap();
+
+    let t =
+        open_ontologies::shape_combinatorics::enumerate(&turtle, "http://example.org/Building", 3)
+            .expect("turtle");
+    let q =
+        open_ontologies::shape_combinatorics::enumerate(&trig, "http://example.org/Building", 3)
+            .expect("trig");
+    assert_eq!(
+        serde_json::to_value(&t).unwrap(),
+        serde_json::to_value(&q).unwrap(),
+        "the same instances must induce the same lattice"
+    );
+}


### PR DESCRIPTION
#126 fixed `onto_shacl`, #122 fixed `onto_shacl_check`. This asks how many other tools have the same defect, and answers it by measurement instead of by reading code.

## The probe

Load identical content twice, once as Turtle and once as TriG with every triple inside a named graph. Run each tool over both. Anything that disagrees is answering about a fraction of the store, because the two stores differ in nothing except which graph the triples sit in.

Four tools measured. **Three were wrong.**

| tool | Turtle | TriG |
| --- | --- | --- |
| `onto_vocab_check` | 4 declared terms, `conforms: true` | 0 terms, bails with a warning |
| `onto_communities` | one community of three | none, "nothing to cluster" |
| shape induction | 1 property, 2 subsets | 0 properties, empty lattice |
| `onto_shacl` | (fixed in #126) | agrees |

None of those looks like a failure, which is the reason this class of defect survives. A clean report over a store that appears to hold nothing is indistinguishable from a clean report over a store that holds nothing.

Two details worth having, both of which I only have because I measured rather than reasoned:

**`onto_vocab_check` does not do what I expected.** I assumed a check with no declared vocabulary would flag every term in the data as hallucinated. It does not. It notices it has zero terms and bails with `conforms: false`, an empty `hallucinated_terms` and a warning telling the caller to load an ontology first. So it is the loud member of the family, and the cost is subtler than a false positive: the advice in the warning is to do the thing the caller has already done, which sends them to inspect their input rather than the tool.

**`onto_communities` states a conclusion it did not reach.** Over a three-node cycle in a named graph it returns the note "no relations between named subjects and objects: nothing to cluster". That is a claim about the corpus, made after looking at none of it.

## The fix, and the rule

All three switch to `sparql_select_union`, added in #126. The rule is now written on `sparql_select` itself, because getting it backwards is what produced every instance of this:

> A query someone typed keeps the default graph: they chose the dataset by writing `GRAPH` or not writing it, and widening it under them changes the meaning of what they wrote. A query this codebase authored to ask a question about the store takes the union, because the answer to "what does this store declare" must not depend on a file format.

## What the test file says about itself

`tests/serialisation_invariance_test.rs` is the probe, kept as a regression pin, and it carries two warnings in its own header.

**A passing test here is worth only as much as its fixture.** Two tools answering "nothing" agree perfectly. The first cut of the community test passed while proving nothing, because its fixture was schema triples and `edges()` deliberately excludes `rdf:type`, `rdfs:subClassOf`, domain, range and the OWL class axioms: it clusters the entity graph, not the schema. Both sides were empty and equal. It now asserts the Turtle side found something before comparing, and I would not have caught it without adding that assertion on suspicion.

**Four of roughly thirty are covered.** Every other module running an internally authored SELECT is unmeasured rather than known-good, and the header names `enforce`, `drift`, `align`, `plan`, `support` and `structembed` as the likeliest. Add a case before fixing one, so the next fix is measured too.

## Verification

Full default suite: **75 binaries, 776 tests, 0 failures**. Each of the three fixes reverted independently reddens exactly its own case and nothing else, tree restored between each. `cargo clippy --all-targets` clean on all four touched source files, re-linted rather than served from cache. `rustfmt --check` at parity with `origin/main` on every pre-existing file (graph 6/6, vocab_check 2/2, communities 3/3, shape_combinatorics 12/12) and clean on the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
