### PR TITLE
Follow-ups: incremental reasoner graph scope + MCP JSON escaping

### DIFF
--- a/src/reason_incremental.rs
+++ b/src/reason_incremental.rs
@@ -123,7 +123,12 @@ impl Schema {
         let truncated = std::cell::Cell::new(false);
         let pairs = |pred: &str| -> anyhow::Result<Vec<(String, String)>> {
             let q = format!("SELECT ?s ?o WHERE {{ ?s {pred} ?o }} LIMIT {SCAN_LIMIT}");
-            let raw = graph.sparql_select(&q)?;
+            // The schema is a question about the whole store: subclass/domain/range
+            // axioms may sit in any named graph (a TriG/N-Quads load, a per-version
+            // schema graph), so read the union, not the default graph alone. Reading
+            // the default graph made incremental reasoning derive nothing for a store
+            // whose schema was not in the default graph, and label it complete.
+            let raw = graph.sparql_select_union(&q)?;
             let parsed: serde_json::Value = serde_json::from_str(&raw)?;
             let rows: Vec<(String, String)> = parsed
                 .get("results")
@@ -146,7 +151,8 @@ impl Schema {
         };
         let typed = |cls: &str| -> anyhow::Result<HashSet<String>> {
             let q = format!("SELECT ?s WHERE {{ ?s {RDF_TYPE} {cls} }} LIMIT {SCAN_LIMIT}");
-            let raw = graph.sparql_select(&q)?;
+            // Property-characteristic declarations are schema, read from every graph.
+            let raw = graph.sparql_select_union(&q)?;
             let parsed: serde_json::Value = serde_json::from_str(&raw)?;
             let rows: HashSet<String> = parsed
                 .get("results")
@@ -252,8 +258,10 @@ impl IncrementalReasoner {
             } else {
                 format!("SELECT ?x WHERE {{ ?x {pred} {term} }} LIMIT 10000")
             };
+            // The neighbours of a delta term are instance edges that may live in any
+            // named graph, so this store-question reads the union too.
             graph
-                .sparql_select(&q)
+                .sparql_select_union(&q)
                 .ok()
                 .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
                 .and_then(|v| v.get("results").and_then(|r| r.as_array()).cloned())

--- a/src/server.rs
+++ b/src/server.rs
@@ -213,6 +213,10 @@ impl OpenOntologiesServer {
 #[tool_router]
 impl OpenOntologiesServer {
 
+    fn err_json(msg: impl std::fmt::Display) -> String {
+        serde_json::json!({ "error": msg.to_string() }).to_string()
+    }
+
     // ── Status ──────────────────────────────────────────────────────────────
 
     #[tool(name = "onto_status", description = "Returns health status of the Open Ontologies server")]
@@ -234,9 +238,9 @@ impl OpenOntologiesServer {
     async fn onto_validate(&self, Parameters(input): Parameters<OntoValidateInput>) -> String {
         use crate::ontology::OntologyService;
         if input.inline.unwrap_or(false) {
-            OntologyService::validate_string(&input.input).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            OntologyService::validate_string(&input.input).unwrap_or_else(Self::err_json)
         } else {
-            OntologyService::validate_file(&input.input).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            OntologyService::validate_file(&input.input).unwrap_or_else(Self::err_json)
         }
     }
 
@@ -249,17 +253,17 @@ impl OpenOntologiesServer {
                     Ok(content) => {
                         if let Some(output) = input.output {
                             match std::fs::write(&output, &content) {
-                                Ok(_) => format!(r#"{{"ok":true,"path":"{}","format":"{}"}}"#, output, input.to),
-                                Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                                Ok(_) => serde_json::json!({"ok":true,"path":output,"format":input.to}).to_string(),
+                                Err(e) => Self::err_json(e),
                             }
                         } else {
                             content
                         }
                     }
-                    Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                    Err(e) => Self::err_json(e),
                 }
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -269,7 +273,7 @@ impl OpenOntologiesServer {
             // Inline turtle bypasses the registry/cache (no source file).
             match self.graph.load_turtle(&turtle, None) {
                 Ok(count) => format!(r#"{{"ok":true,"triples_loaded":{},"source":"inline"}}"#, count),
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => Self::err_json(e),
             }
         } else if let Some(path) = input.path {
             let path = expand_tilde(&path);
@@ -287,7 +291,7 @@ impl OpenOntologiesServer {
                     "origin": res.origin,
                     "cache_path": res.cache_path,
                 }).to_string(),
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+                Err(e) => Self::err_json(e),
             }
         } else {
             r#"{"error":"Either 'path' or 'turtle' must be provided"}"#.to_string()
@@ -308,10 +312,7 @@ impl OpenOntologiesServer {
             match crate::repo::resolve_within_repos(dir, repos) {
                 Ok((start, repo_root)) => crate::repo::list_one(&repo_root, &start, recursive),
                 Err(e) => {
-                    return format!(
-                        r#"{{"error":"{}"}}"#,
-                        e.to_string().replace('"', "'")
-                    );
+                    return Self::err_json(e);
                 }
             }
         } else {
@@ -393,10 +394,7 @@ impl OpenOntologiesServer {
         let path = match crate::repo::resolve_load_target(&input.name, repos) {
             Ok(p) => p,
             Err(e) => {
-                return format!(
-                    r#"{{"error":"{}"}}"#,
-                    e.to_string().replace('"', "'")
-                );
+                return Self::err_json(e);
             }
         };
         let opts = crate::registry::LoadOptions {
@@ -414,37 +412,37 @@ impl OpenOntologiesServer {
                 "cache_path": res.cache_path,
             })
             .to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
     #[tool(name = "onto_query", description = "Run a SPARQL query against the loaded ontology store. If the active ontology has been evicted from memory (idle TTL), it is transparently reloaded from the compile cache before the query runs.")]
     async fn onto_query(&self, Parameters(input): Parameters<OntoQueryInput>) -> String {
         if let Err(e) = self.registry.ensure_loaded() {
-            return format!(r#"{{"error":"ensure_loaded: {}"}}"#, e.to_string().replace('"', "'"));
+            return Self::err_json(format!("ensure_loaded: {e}"));
         }
-        self.graph.sparql_select(&input.query).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+        self.graph.sparql_select(&input.query).unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_save", description = "Save the current ontology store to a file")]
     async fn onto_save(&self, Parameters(input): Parameters<OntoSaveInput>) -> String {
         if let Err(e) = self.registry.ensure_loaded() {
-            return format!(r#"{{"error":"ensure_loaded: {}"}}"#, e.to_string().replace('"', "'"));
+            return Self::err_json(format!("ensure_loaded: {e}"));
         }
         let format = input.format.as_deref().unwrap_or("turtle");
         let path = expand_tilde(&input.path);
         match self.graph.save_file(&path, format) {
-            Ok(_) => format!(r#"{{"ok":true,"path":"{}","format":"{}"}}"#, path, format),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(_) => serde_json::json!({"ok":true,"path":path,"format":format}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
     #[tool(name = "onto_stats", description = "Get statistics about the loaded ontology (triple count, classes, properties, individuals)")]
     fn onto_stats(&self) -> String {
         if let Err(e) = self.registry.ensure_loaded() {
-            return format!(r#"{{"error":"ensure_loaded: {}"}}"#, e.to_string().replace('"', "'"));
+            return Self::err_json(format!("ensure_loaded: {e}"));
         }
-        self.graph.get_stats().unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+        self.graph.get_stats().unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_diff", description = "Compare two ontology files and show added/removed triples")]
@@ -452,13 +450,13 @@ impl OpenOntologiesServer {
         use crate::ontology::OntologyService;
         let old = match std::fs::read_to_string(&input.old_path) {
             Ok(c) => c,
-            Err(e) => return format!(r#"{{"error":"Cannot read {}: {}"}}"#, input.old_path, e),
+            Err(e) => return Self::err_json(format!("Cannot read {}: {}", input.old_path, e)),
         };
         let new = match std::fs::read_to_string(&input.new_path) {
             Ok(c) => c,
-            Err(e) => return format!(r#"{{"error":"Cannot read {}: {}"}}"#, input.new_path, e),
+            Err(e) => return Self::err_json(format!("Cannot read {}: {}", input.new_path, e)),
         };
-        OntologyService::diff(&old, &new).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+        OntologyService::diff(&old, &new).unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_lint", description = "Check an ontology for quality issues: missing labels, comments, domains, ranges")]
@@ -469,10 +467,10 @@ impl OpenOntologiesServer {
         } else {
             match std::fs::read_to_string(&input.input) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => return Self::err_json(e),
             }
         };
-        OntologyService::lint_with_feedback(&content, Some(&self.db)).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+        OntologyService::lint_with_feedback(&content, Some(&self.db)).unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_clear", description = "Clear all triples from the in-memory ontology store and unload the active registry slot (cache file is preserved)")]
@@ -481,7 +479,7 @@ impl OpenOntologiesServer {
         let _ = self.registry.unload(false);
         match self.graph.clear() {
             Ok(_) => r#"{"ok":true,"message":"Store cleared"}"#.to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -501,13 +499,13 @@ impl OpenOntologiesServer {
                     "name": name,
                     "message": "entry exists in cache but was not in memory; pass delete_cache=true to remove it",
                 }).to_string(),
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+                Err(e) => Self::err_json(e),
             };
         }
         match self.registry.unload(del) {
             Ok(Some(name)) => serde_json::json!({"ok": true, "unloaded": name, "deleted_cache": del}).to_string(),
             Ok(None) => r#"{"ok":true,"unloaded":null,"message":"no active ontology"}"#.to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -525,7 +523,7 @@ impl OpenOntologiesServer {
                 "origin": res.origin,
                 "cache_path": res.cache_path,
             }).to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -542,7 +540,7 @@ impl OpenOntologiesServer {
                 "count": entries.len(),
                 "entries": entries,
             }).to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -561,7 +559,7 @@ impl OpenOntologiesServer {
                 "name": input.name,
                 "message": "entry was found but delete_file=false and it was not active, so nothing changed",
             }).to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -818,13 +816,13 @@ impl OpenOntologiesServer {
                                     "individuals": stats_val["individuals"],
                                 }).to_string()
                             }
-                            Err(e) => format!(r#"{{"error":"Parse error for {}: {}"}}"#, id, e),
+                            Err(e) => Self::err_json(format!("Parse error for {}: {}", id, e)),
                         }
                     }
-                    Err(e) => format!(r#"{{"error":"Fetch error for {}: {}"}}"#, id, e),
+                    Err(e) => Self::err_json(format!("Fetch error for {}: {}", id, e)),
                 }
             }
-            other => format!(r#"{{"error":"Unknown action '{}'. Use 'list' or 'install'."}}"#, other),
+            other => Self::err_json(format!("Unknown action '{}'. Use 'list' or 'install'.", other)),
         }
     }
 
@@ -874,7 +872,7 @@ impl OpenOntologiesServer {
         });
         if let Some(sparql) = input.sparql.as_deref() {
             if let Err(e) = self.registry.ensure_loaded() {
-                return format!(r#"{{"error":"ensure_loaded: {}"}}"#, e.to_string().replace('"', "'"));
+                return Self::err_json(format!("ensure_loaded: {e}"));
             }
             match self.graph.sparql_select(sparql) {
                 Ok(json) => {
@@ -900,21 +898,21 @@ impl OpenOntologiesServer {
     async fn onto_version(&self, Parameters(input): Parameters<OntoVersionInput>) -> String {
         use crate::ontology::OntologyService;
         OntologyService::save_version(&self.db, &self.graph, &input.label)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_history", description = "List all saved ontology version snapshots")]
     fn onto_history(&self) -> String {
         use crate::ontology::OntologyService;
         OntologyService::list_versions(&self.db)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_rollback", description = "Restore the ontology store to a previously saved version")]
     async fn onto_rollback(&self, Parameters(input): Parameters<OntoRollbackInput>) -> String {
         use crate::ontology::OntologyService;
         OntologyService::rollback_version(&self.db, &self.graph, &input.label)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     // ── Data ingestion & reasoning ─────────────────────────────────────────
@@ -929,7 +927,7 @@ impl OpenOntologiesServer {
         // Parse data file
         let rows = match DataIngester::parse_file(&input.path) {
             Ok(r) => r,
-            Err(e) => return format!(r#"{{"error":"Failed to parse {}: {}"}}"#, input.path, e),
+            Err(e) => return Self::err_json(format!("Failed to parse {}: {}", input.path, e)),
         };
 
         if rows.is_empty() {
@@ -941,15 +939,15 @@ impl OpenOntologiesServer {
             if input.inline_mapping.unwrap_or(false) {
                 match serde_json::from_str::<MappingConfig>(mapping_str) {
                     Ok(m) => m,
-                    Err(e) => return format!(r#"{{"error":"Invalid mapping JSON: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Invalid mapping JSON: {}", e)),
                 }
             } else {
                 match std::fs::read_to_string(mapping_str) {
                     Ok(content) => match serde_json::from_str::<MappingConfig>(&content) {
                         Ok(m) => m,
-                        Err(e) => return format!(r#"{{"error":"Invalid mapping file: {}"}}"#, e),
+                        Err(e) => return Self::err_json(format!("Invalid mapping file: {}", e)),
                     },
-                    Err(e) => return format!(r#"{{"error":"Cannot read mapping file: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Cannot read mapping file: {}", e)),
                 }
             }
         } else {
@@ -1006,7 +1004,7 @@ impl OpenOntologiesServer {
                     "provenance_triples": prov_triples,
                 }).to_string()
             }
-            Err(e) => format!(r#"{{"error":"Failed to load triples: {}"}}"#, e),
+            Err(e) => Self::err_json(format!("Failed to load triples: {}", e)),
         }
     }
 
@@ -1020,7 +1018,7 @@ impl OpenOntologiesServer {
             // text: a backslash or a newline would break the JSON. That is
             // why `temporal::argument` (the wrapper over `instant::argument`)
             // does not quote the argument in its message.
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1036,7 +1034,7 @@ impl OpenOntologiesServer {
             // text: a backslash or a newline would break the JSON. That is
             // why `temporal::argument` (the wrapper over `instant::argument`)
             // does not quote the argument in its message.
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1051,7 +1049,7 @@ impl OpenOntologiesServer {
             // handler takes no argument, so nothing caller-supplied reaches
             // it today; the rule is stated so an argument added later
             // inherits it.
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1064,7 +1062,7 @@ impl OpenOntologiesServer {
         }
         match IncrementalReasoner::run(&self.graph, &delta, input.materialize.unwrap_or(true)) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1074,7 +1072,7 @@ impl OpenOntologiesServer {
         let checker = SupportChecker::new(self.graph.clone(), self.db.clone());
         match checker.check(input.prov_predicate.as_deref(), input.limit.unwrap_or(25)) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1084,7 +1082,7 @@ impl OpenOntologiesServer {
         let checker = SupportChecker::new(self.graph.clone(), self.db.clone());
         match checker.record_verdict(&input.claim_id, &input.verdict, input.note.as_deref()) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1094,7 +1092,7 @@ impl OpenOntologiesServer {
         let checker = SupportChecker::new(self.graph.clone(), self.db.clone());
         match checker.report(input.prov_predicate.as_deref()) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1124,7 +1122,7 @@ impl OpenOntologiesServer {
             &input.version.unwrap_or_else(|| "1.0.0".into()), evidence,
         ) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1133,7 +1131,7 @@ impl OpenOntologiesServer {
         use crate::pack::Packer;
         match Packer::new(self.graph.clone()).unpack(&input.path, input.verify_only.unwrap_or(false)) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1143,7 +1141,7 @@ impl OpenOntologiesServer {
         let detector = Communities::new(self.graph.clone());
         match detector.detect(input.min_size.unwrap_or(3), input.top_members.unwrap_or(8)) {
             Ok(json) => json,
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'")),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1154,7 +1152,7 @@ impl OpenOntologiesServer {
 
         let rows = match DataIngester::parse_file(&input.data_path) {
             Ok(r) => r,
-            Err(e) => return format!(r#"{{"error":"Failed to parse {}: {}"}}"#, input.data_path, e),
+            Err(e) => return Self::err_json(format!("Failed to parse {}: {}", input.data_path, e)),
         };
         let headers = DataIngester::extract_headers(&rows);
 
@@ -1204,7 +1202,7 @@ impl OpenOntologiesServer {
         if let Some(ref save_path) = input.save_path
             && let Ok(json) = serde_json::to_string_pretty(&mapping)
                 && let Err(e) = std::fs::write(save_path, &json) {
-                    return format!(r#"{{"error":"Cannot write mapping file: {}"}}"#, e);
+                    return Self::err_json(format!("Cannot write mapping file: {}", e));
                 }
 
         result.to_string()
@@ -1218,11 +1216,11 @@ impl OpenOntologiesServer {
         } else {
             match std::fs::read_to_string(&input.shapes) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"Cannot read shapes file: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("Cannot read shapes file: {}", e)),
             }
         };
         ShaclValidator::validate(&self.graph, &shapes)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_ossie_import", description = "Compile an Apache Ossie (incubating, formerly Open Semantic Interchange) ontology document into OWL 2 DL + SHACL, and optionally load it into the active store so every other tool here works on it. Ossie is the vendor-neutral semantic-model spec backed by Snowflake, Salesforce, Databricks, dbt Labs and ~50 other platforms; its ontology module is a fact-based conceptual model (EntityType/ValueType concepts, roles, multiplicities, verbalizations, identifiers, derivation rules) that references neither RDF, OWL, SKOS nor SHACL. That means an Ossie ontology is invisible to every reasoner and validator in the semantic web stack until it is compiled. This tool does the compile: concepts become owl:Class / rdfs:Datatype, binary relationships become object/datatype properties, `identify_by` becomes owl:hasKey, unary relationships become subclasses, arity>=3 relationships are reified (W3C n-ary pattern 1), and the recognised `requires` fragment becomes XSD facets mirrored into SHACL. FOUR Ossie constructs have no OWL 2 DL expression and are carried by SHACL or by annotation instead: OneToOne onto a ValueType (that is InverseFunctionalDataProperty, forbidden in OWL 2 DL — and it is the COMMON case, since a preferred identifier is by construction a relationship to a value type), ManyToOne on arity>=3 (a tuple functional dependency), `derived_by` (a recursive rule language) and `requires` beyond scalar comparison. Every one of these is reported in `issues` and preserved verbatim as an ossie: annotation, so nothing is silently dropped. After `load=true`, run onto_reason / onto_dl_explain / onto_shacl / onto_query against a semantic model that previously had no formal semantics at all.")]
@@ -1287,11 +1285,11 @@ impl OpenOntologiesServer {
         } else {
             match std::fs::read_to_string(&input.shapes) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"Cannot read shapes file: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("Cannot read shapes file: {}", e)),
             }
         };
         ShaclValidator::check_shapes(&self.graph, &shapes)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_vocab_check", description = "Closed-world vocabulary check on a Turtle DATA graph: verify that every predicate and every rdf:type class used in the data is actually DECLARED in the loaded ontology. Catches hallucinated/undeclared terms — e.g. an LLM emitting `ies:hasDeparturePort` when the ontology only defines `ies:scheduledDeparturePort`. This is the gate open-world SHACL structurally CANNOT provide: SHACL silently ignores predicates it has no shape for, so a graph full of invented terms still reports conforms=true. Only IRIs whose namespace belongs to the ontology (plus any passed in `namespaces`) are policed; standard rdf/rdfs/owl/xsd/sh vocabulary and your instance-data IRIs are never flagged. Returns {conforms, hallucinated_terms, checked_namespaces}. Companion to `onto_shacl` (open-world structural validation of data) and `onto_shacl_check` (checks proposed SHACL shapes); run this on generated data to catch fabricated vocabulary before it enters the store.")]
@@ -1301,32 +1299,32 @@ impl OpenOntologiesServer {
         } else {
             match std::fs::read_to_string(&input.data) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"Cannot read data file: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("Cannot read data file: {}", e)),
             }
         };
         let extra = input.namespaces.clone().unwrap_or_default();
         crate::vocab_check::check_data_vocab(&self.graph, &data, &extra)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_align_flora", description = "End-to-end FLORA alignment (#38). Takes the currently-loaded graph as source and a Turtle string for target, enumerates plausible class-pairs (pre-filtered by shared label tokens), extracts the four FLORA signals per pair (label Jaccard, parent overlap, sibling overlap, datatype overlap) from the structural neighbourhood, runs the 10-rule Mamdani inference engine, and returns only the accept-verdict pairs. Companion to `onto_align_fuzzy` (per-pair adjudication when you already have signals).")]
     async fn onto_align_flora(&self, Parameters(input): Parameters<OntoAlignFloraInput>) -> String {
         let target = std::sync::Arc::new(crate::graph::GraphStore::new());
         if let Err(e) = target.load_turtle(&input.target_ttl, None) {
-            return format!(r#"{{"error":"target_ttl failed to parse: {}"}}"#, e);
+            return Self::err_json(format!("target_ttl failed to parse: {}", e));
         }
         let low = input.low_threshold.unwrap_or(0.4);
         let high = input.high_threshold.unwrap_or(0.65);
         let report = crate::flora_pipeline::align_with_flora(&self.graph, &target, low, high);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "onto_align_fuzzy", description = "FLORA-style fuzzy-logic alignment adjudication (#38, ISWC 2025 Best Paper). Caller supplies per-pair signals (`label_jaccard`, `parent_overlap`, `sibling_overlap`, `datatype_overlap` all in [0,1]) plus low/high thresholds; server combines via the chosen t-norm (`min` / `product` / `lukasiewicz`) and emits verdict `\"accept\"` / `\"borderline\"` / `\"reject\"` plus a rule trace. Embedding-free, interpretable, complements the HNSW candidate-generator pipeline.")]
     async fn onto_align_fuzzy(&self, Parameters(input): Parameters<OntoAlignFuzzyInput>) -> String {
         let signals: crate::align_fuzzy::FuzzySignals = match serde_json::from_str(&input.signals_json) {
             Ok(s) => s,
-            Err(e) => return format!(r#"{{"error":"invalid signals_json: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("invalid signals_json: {}", e)),
         };
         let tnorm = match input.tnorm.as_deref() {
             Some("product") => crate::align_fuzzy::TNorm::Product,
@@ -1335,7 +1333,7 @@ impl OpenOntologiesServer {
         };
         let decision = crate::align_fuzzy::adjudicate(&signals, tnorm, input.low_threshold, input.high_threshold);
         serde_json::to_string(&decision)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "onto_policy_register", description = "Register an ARGOS-style policy rule (#40, ISWC 2025 WOP). `effect` is `\"allow\"` or `\"deny\"`; `condition` is a SPARQL ASK that can use the `{target}` placeholder. Pairs with `onto_policy_check` and `onto_certify_action` — CIVeX gates causal risk, ARGOS gates authorisation.")]
@@ -1347,8 +1345,8 @@ impl OpenOntologiesServer {
             description: input.description,
         };
         match crate::policy::register_rule(&self.db, &rule) {
-            Ok(()) => format!(r#"{{"ok":true,"registered":"{}"}}"#, input.name),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"registered":input.name}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1356,8 +1354,8 @@ impl OpenOntologiesServer {
     async fn onto_policy_list(&self) -> String {
         match crate::policy::list_rules(&self.db) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1365,8 +1363,8 @@ impl OpenOntologiesServer {
     async fn onto_policy_check(&self, Parameters(input): Parameters<OntoPolicyCheckInput>) -> String {
         match crate::policy::check_action(&self.db, &self.graph, &input.target_iris) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1374,30 +1372,30 @@ impl OpenOntologiesServer {
     async fn eval_rag_mmrag(&self, Parameters(input): Parameters<OntoEvalRagMmragInput>) -> String {
         let qas = match crate::eval_rag::parse_mmrag_dataset(&input.dataset_json) {
             Ok(q) => q,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
         let report = crate::eval_rag::evaluate(&qas);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "eval_rag", description = "mmRAG benchmark scoring (#41, ISWC 2025). Input is a JSON array of {question_id, gold_iri, retrieved: [iri, ...]}. Returns Hit@{3,5,10}, MRR, exact-match-at-1, and per-question rank (0 = gold not retrieved).")]
     async fn eval_rag(&self, Parameters(input): Parameters<OntoEvalRagInput>) -> String {
         let qas: Vec<crate::eval_rag::RagQa> = match serde_json::from_str(&input.qa_json) {
             Ok(q) => q,
-            Err(e) => return format!(r#"{{"error":"invalid qa_json: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("invalid qa_json: {}", e)),
         };
         let report = crate::eval_rag::evaluate(&qas);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "onto_classify_el", description = "Classify the loaded ontology in the OWL-EL fragment (#30). Materialises OWL-RL-ext entailments in a sandbox copy of the graph and emits every distinct subsumption `?sub rdfs:subClassOf ?super` (transitive closure, deduplicated, owl:Thing-trivial pairs removed). For deep SHOIQ subsumption, use `onto_dl_check` / `onto_dl_explain`.")]
     async fn onto_classify_el(&self) -> String {
         match crate::classify_el::classify(&self.graph) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1406,16 +1404,16 @@ impl OpenOntologiesServer {
         let reference: Vec<crate::eval_alignment::AlignmentEntry> =
             match serde_json::from_str(&input.reference_json) {
                 Ok(r) => r,
-                Err(e) => return format!(r#"{{"error":"invalid reference_json: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("invalid reference_json: {}", e)),
             };
         let computed: Vec<crate::eval_alignment::AlignmentEntry> =
             match serde_json::from_str(&input.computed_json) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"invalid computed_json: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("invalid computed_json: {}", e)),
             };
         let report = crate::eval_alignment::evaluate(&reference, &computed);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "onto_shape_induce", description = "Kastor-style data-driven SHACL shape induction (#36, K-CAP 2025). For each property subset up to `max_size`, compute support (fraction of class instances having all properties) and confidence (fraction of any-instances-with-properties that are class members). Returns the top-k candidates ranked by `support × confidence`, each carrying a ready-to-use SHACL NodeShape Turtle block. Filter via `min_support` (default 0.1) and `min_confidence` (default 0.5).")]
@@ -1426,8 +1424,8 @@ impl OpenOntologiesServer {
         let min_confidence = input.min_confidence.unwrap_or(0.5);
         match crate::shape_combinatorics::induce_shapes(&self.graph, &input.class_iri, max, top_k, min_support, min_confidence) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1436,8 +1434,8 @@ impl OpenOntologiesServer {
         let max = input.max_size.unwrap_or(3).min(8); // hard cap: guards the combinatorial blow-up at the tool boundary
         match crate::shape_combinatorics::enumerate(&self.graph, &input.class_iri, max) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1446,11 +1444,11 @@ impl OpenOntologiesServer {
         let candidates: Vec<crate::borderline_loop::Candidate> =
             match serde_json::from_str(&input.candidates_json) {
                 Ok(c) => c,
-                Err(e) => return format!(r#"{{"error":"invalid candidates_json: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("invalid candidates_json: {}", e)),
             };
         let report = crate::borderline_loop::partition(candidates, input.low_threshold, input.high_threshold);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "borderline_record_verdict", description = "Persist an orchestrator's verdict on a borderline candidate (#37). verdict must be \"accept\" or \"reject\". Namespaces let independent borderline loops coexist.")]
@@ -1462,8 +1460,8 @@ impl OpenOntologiesServer {
             rationale: input.rationale,
         };
         match crate::borderline_loop::record_verdict(&self.db, &v) {
-            Ok(()) => format!(r#"{{"ok":true,"candidate_id":"{}"}}"#, input.candidate_id),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"candidate_id":input.candidate_id}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1471,8 +1469,8 @@ impl OpenOntologiesServer {
     async fn onto_extract_scaffold(&self, Parameters(input): Parameters<OntoExtractScaffoldInput>) -> String {
         match crate::extract_scaffold::build_scaffold(&self.graph, &input.class_iri) {
             Ok(s) => serde_json::to_string(&s)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1481,12 +1479,12 @@ impl OpenOntologiesServer {
         let scaffold: crate::extract_scaffold::ExtractionScaffold =
             match serde_json::from_str(&input.scaffold_json) {
                 Ok(s) => s,
-                Err(e) => return format!(r#"{{"error":"invalid scaffold_json: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("invalid scaffold_json: {}", e)),
             };
         match crate::extract_scaffold::validate_extraction(&scaffold, &input.extraction_json) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1494,11 +1492,11 @@ impl OpenOntologiesServer {
     async fn onto_cq_run(&self, Parameters(input): Parameters<OntoCqRunInput>) -> String {
         let cqs: Vec<crate::cq::CompetencyQuestion> = match serde_json::from_str(&input.cqs_json) {
             Ok(c) => c,
-            Err(e) => return format!(r#"{{"error":"invalid cqs_json: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("invalid cqs_json: {}", e)),
         };
         let report = crate::cq::run_cq_suite(&self.graph, &cqs);
         serde_json::to_string(&report)
-            .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e))
+            .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e)))
     }
 
     #[tool(name = "onto_verify_cq", description = "Persist an LLM-supplied (or human-supplied) verdict on a CQ result (#39, ISWC 2025 Lippolis). verdict must be one of \"correct\", \"incorrect\", \"partial\". Server stores verdicts; the LLM does the judging. Pairs with `onto_cq_run`.")]
@@ -1510,8 +1508,8 @@ impl OpenOntologiesServer {
             judge: input.judge,
         };
         match crate::cq::verify_cq(&self.db, &v) {
-            Ok(()) => format!(r#"{{"ok":true,"cq_id":"{}"}}"#, input.cq_id),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"cq_id":input.cq_id}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1519,8 +1517,8 @@ impl OpenOntologiesServer {
     async fn onto_cq_verdicts_list(&self, Parameters(input): Parameters<OntoCqVerdictsListInput>) -> String {
         match crate::cq::list_cq_verdicts(&self.db, &input.cq_id) {
             Ok(v) => serde_json::to_string(&v)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1530,8 +1528,8 @@ impl OpenOntologiesServer {
         let include_abox = input.include_abox.unwrap_or(false);
         match crate::segment_retrieve::retrieve_segment(&self.graph, &input.seed_iris, hops, include_abox) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1539,8 +1537,8 @@ impl OpenOntologiesServer {
     async fn onto_coevolve_dependency_graph(&self, Parameters(input): Parameters<OntoCoevolveDepGraphInput>) -> String {
         match crate::coevolve::build_dependency_graph(&input.shapes_ttl) {
             Ok(d) => serde_json::to_string(&d)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1549,8 +1547,8 @@ impl OpenOntologiesServer {
         let profile = input.profile.unwrap_or_else(|| "owl-rl".to_string());
         match crate::coevolve::incremental_check(&self.graph, &input.shapes_ttl, &input.changed_iris, &profile) {
             Ok(r) => serde_json::to_string(&r)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1559,8 +1557,8 @@ impl OpenOntologiesServer {
         let profile = input.profile.unwrap_or_else(|| "owl-rl".to_string());
         match crate::coevolve::coevolve_check(&self.graph, &input.shapes_ttl, &profile) {
             Ok(report) => serde_json::to_string(&report)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1568,8 +1566,8 @@ impl OpenOntologiesServer {
     async fn graph_projection_lossy_check(&self, Parameters(input): Parameters<GraphProjectionLossyCheckInput>) -> String {
         match crate::projection_check::check_projection_loss(&self.graph, &input.source_iris, &input.projected_ttl) {
             Ok(report) => serde_json::to_string(&report)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1595,8 +1593,8 @@ impl OpenOntologiesServer {
         };
         match crate::civex::certify_action(&self.db, &self.graph, &frame) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1606,12 +1604,12 @@ impl OpenOntologiesServer {
     async fn onto_action_register(&self, Parameters(input): Parameters<OntoActionRegisterInput>) -> String {
         let schema: crate::dynamics::ActionSchema = match serde_json::from_str(&input.schema_json) {
             Ok(s) => s,
-            Err(e) => return format!(r#"{{"error":"invalid schema_json: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("invalid schema_json: {}", e)),
         };
         let name = schema.name.clone();
         match crate::dynamics::register(&self.db, &schema) {
-            Ok(()) => format!(r#"{{"ok":true,"registered":"{}"}}"#, name),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"registered":name}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1619,8 +1617,8 @@ impl OpenOntologiesServer {
     async fn onto_action_applicable(&self, Parameters(input): Parameters<OntoActionApplicableInput>) -> String {
         let schema = match crate::dynamics::lookup(&self.db, &input.action_name) {
             Ok(Some(s)) => s,
-            Ok(None) => return format!(r#"{{"error":"unknown action: {}"}}"#, input.action_name),
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Ok(None) => return Self::err_json(format!("unknown action: {}", input.action_name)),
+            Err(e) => return Self::err_json(e),
         };
         let bindings: Vec<(String, String)> = input.bindings.into_iter().collect();
         let applicable = schema.applicable(&self.graph, &bindings);
@@ -1637,8 +1635,8 @@ impl OpenOntologiesServer {
     async fn onto_action_apply(&self, Parameters(input): Parameters<OntoActionApplyInput>) -> String {
         let schema = match crate::dynamics::lookup(&self.db, &input.action_name) {
             Ok(Some(s)) => s,
-            Ok(None) => return format!(r#"{{"error":"unknown action: {}"}}"#, input.action_name),
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Ok(None) => return Self::err_json(format!("unknown action: {}", input.action_name)),
+            Err(e) => return Self::err_json(e),
         };
         let bindings: Vec<(String, String)> = input.bindings.into_iter().collect();
         if input.check_preconditions && !schema.applicable(&self.graph, &bindings) {
@@ -1655,8 +1653,8 @@ impl OpenOntologiesServer {
         };
         match outcome {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1672,8 +1670,8 @@ impl OpenOntologiesServer {
             .collect();
         match crate::dynamics_bcplus::apply_concurrent(&self.db, &self.graph, &steps) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1685,8 +1683,8 @@ impl OpenOntologiesServer {
             description: input.description,
         };
         match crate::dynamics_bcplus::register_invariant(&self.db, &law) {
-            Ok(()) => format!(r#"{{"ok":true,"registered":"{}"}}"#, input.name),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"registered":input.name}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1694,8 +1692,8 @@ impl OpenOntologiesServer {
     async fn onto_invariant_list(&self) -> String {
         match crate::dynamics_bcplus::list_invariants(&self.db) {
             Ok(laws) => serde_json::to_string(&laws)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1703,7 +1701,7 @@ impl OpenOntologiesServer {
     async fn onto_invariant_remove(&self, Parameters(input): Parameters<OntoInvariantRemoveInput>) -> String {
         match crate::dynamics_bcplus::remove_invariant(&self.db, &input.name) {
             Ok(removed) => format!(r#"{{"removed":{}}}"#, removed),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1711,8 +1709,8 @@ impl OpenOntologiesServer {
     async fn onto_invariant_check(&self) -> String {
         match crate::dynamics_bcplus::check_invariants(&self.db, &self.graph) {
             Ok(violations) => serde_json::to_string(&violations)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1728,8 +1726,8 @@ impl OpenOntologiesServer {
             description: input.description,
         };
         match crate::dynamics_bcplus::register_default(&self.db, &law) {
-            Ok(()) => format!(r#"{{"ok":true,"registered":"{}"}}"#, input.name),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Ok(()) => serde_json::json!({"ok":true,"registered":input.name}).to_string(),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1737,8 +1735,8 @@ impl OpenOntologiesServer {
     async fn onto_default_apply(&self) -> String {
         match crate::dynamics_bcplus::apply_defaults(&self.db, &self.graph) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1746,8 +1744,8 @@ impl OpenOntologiesServer {
     async fn onto_action_list(&self) -> String {
         match crate::dynamics::list_names(&self.db) {
             Ok(names) => serde_json::to_string(&names)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1760,8 +1758,8 @@ impl OpenOntologiesServer {
             input.search.as_deref(),
         ) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1778,8 +1776,8 @@ impl OpenOntologiesServer {
             .collect();
         match crate::plan_validate::validate_plan(&self.db, &self.graph, &steps, &goal_facts) {
             Ok(result) => serde_json::to_string(&result)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1789,7 +1787,7 @@ impl OpenOntologiesServer {
         let names = if input.action_names.is_empty() {
             match crate::dynamics::list_names(&self.db) {
                 Ok(n) => n,
-                Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => return Self::err_json(e),
             }
         } else {
             input.action_names
@@ -1798,8 +1796,8 @@ impl OpenOntologiesServer {
         for n in &names {
             match crate::dynamics::lookup(&self.db, n) {
                 Ok(Some(s)) => schemas.push(s),
-                Ok(None) => return format!(r#"{{"error":"unknown action: {}"}}"#, n),
-                Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+                Ok(None) => return Self::err_json(format!("unknown action: {}", n)),
+                Err(e) => return Self::err_json(e),
             }
         }
 
@@ -1876,21 +1874,21 @@ impl OpenOntologiesServer {
         let profile = input.profile.as_deref().unwrap_or("rdfs");
         let materialize = input.materialize.unwrap_or(true);
         Reasoner::run(&self.graph, profile, materialize)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_dl_explain", description = "Explain why a class is unsatisfiable using DL tableaux reasoning. Returns an explanation trace showing the logical contradictions that make the class impossible to instantiate.")]
     async fn onto_dl_explain(&self, Parameters(input): Parameters<OntoDlExplainInput>) -> String {
         use crate::tableaux::DlReasoner;
         DlReasoner::explain_class(&self.graph, &input.class_iri)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_dl_check", description = "Check if one class is subsumed by another using DL tableaux reasoning. Returns whether sub_class is a subclass of super_class, with justification.")]
     async fn onto_dl_check(&self, Parameters(input): Parameters<OntoDlCheckInput>) -> String {
         use crate::tableaux::DlReasoner;
         DlReasoner::check_subsumption(&self.graph, &input.sub_class, &input.super_class)
-            .unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+            .unwrap_or_else(Self::err_json)
     }
 
     // ── v2: Lifecycle tools ─────────────────────────────────────────────────
@@ -1907,7 +1905,7 @@ impl OpenOntologiesServer {
                 self.lineage().record(&self.session_id, "P", "plan", "computed");
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1930,7 +1928,7 @@ impl OpenOntologiesServer {
                 }
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -1960,7 +1958,7 @@ impl OpenOntologiesServer {
                         .record(&self.session_id, "D", "drift", "detected:kgcl");
                     report.to_cnl()
                 }
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => Self::err_json(e),
             },
             "kgcl_json" => match detector.detect_kgcl(&input.version_a, &input.version_b, threshold) {
                 Ok(report) => {
@@ -1968,14 +1966,14 @@ impl OpenOntologiesServer {
                         .record(&self.session_id, "D", "drift", "detected:kgcl_json");
                     report.to_json().to_string()
                 }
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => Self::err_json(e),
             },
             _ => match detector.detect(&input.version_a, &input.version_b) {
                 Ok(result) => {
                     self.lineage().record(&self.session_id, "D", "drift", "detected");
                     result
                 }
-                Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                Err(e) => Self::err_json(e),
             },
         }
     }
@@ -1988,7 +1986,7 @@ impl OpenOntologiesServer {
                 self.lineage().record(&self.session_id, "E", "enforce", &input.rule_pack);
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2006,7 +2004,7 @@ impl OpenOntologiesServer {
 
         let result = monitor.run_watchers();
         self.lineage().record(&self.session_id, "M", "monitor", &result.status);
-        serde_json::to_string(&result).unwrap_or_else(|e| format!(r#"{{"error":"{}"}}"#, e))
+        serde_json::to_string(&result).unwrap_or_else(Self::err_json)
     }
 
     #[tool(name = "onto_monitor_clear", description = "Clear the monitor blocked flag, allowing apply operations to proceed.")]
@@ -2032,7 +2030,7 @@ impl OpenOntologiesServer {
                     })).collect::<Vec<_>>(),
                 }).to_string()
             }
-            Err(e) => format!(r#"{{"error":"Crosswalks not loaded: {}. Run scripts/build_crosswalks.py first."}}"#, e),
+            Err(e) => Self::err_json(format!("Crosswalks not loaded: {}. Run scripts/build_crosswalks.py first.", e)),
         }
     }
 
@@ -2040,7 +2038,7 @@ impl OpenOntologiesServer {
     async fn onto_enrich(&self, Parameters(input): Parameters<OntoEnrichInput>) -> String {
         match crate::clinical::ClinicalCrosswalks::load("data/crosswalks.parquet") {
             Ok(cw) => cw.enrich(&self.graph, &input.class_iri, &input.code, &input.system),
-            Err(e) => format!(r#"{{"error":"Crosswalks not loaded: {}"}}"#, e),
+            Err(e) => Self::err_json(format!("Crosswalks not loaded: {}", e)),
         }
     }
 
@@ -2048,7 +2046,7 @@ impl OpenOntologiesServer {
     fn onto_validate_clinical(&self) -> String {
         match crate::clinical::ClinicalCrosswalks::load("data/crosswalks.parquet") {
             Ok(cw) => cw.validate_clinical(&self.graph),
-            Err(e) => format!(r#"{{"error":"Crosswalks not loaded: {}"}}"#, e),
+            Err(e) => Self::err_json(format!("Crosswalks not loaded: {}", e)),
         }
     }
 
@@ -2074,22 +2072,22 @@ impl OpenOntologiesServer {
         // 1. Ingest
         let rows = match DataIngester::parse_file(&input.data_path) {
             Ok(r) => r,
-            Err(e) => return format!(r#"{{"error":"Ingest failed: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("Ingest failed: {}", e)),
         };
 
         let mapping = if let Some(ref mapping_str) = input.mapping {
             if input.inline_mapping.unwrap_or(false) {
                 match serde_json::from_str::<MappingConfig>(mapping_str) {
                     Ok(m) => m,
-                    Err(e) => return format!(r#"{{"error":"Invalid mapping: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Invalid mapping: {}", e)),
                 }
             } else {
                 match std::fs::read_to_string(mapping_str) {
                     Ok(content) => match serde_json::from_str::<MappingConfig>(&content) {
                         Ok(m) => m,
-                        Err(e) => return format!(r#"{{"error":"Invalid mapping file: {}"}}"#, e),
+                        Err(e) => return Self::err_json(format!("Invalid mapping file: {}", e)),
                     },
-                    Err(e) => return format!(r#"{{"error":"Cannot read mapping: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Cannot read mapping: {}", e)),
                 }
             }
         } else {
@@ -2100,7 +2098,7 @@ impl OpenOntologiesServer {
         let ntriples = mapping.rows_to_ntriples(&rows);
         let triples_loaded = match self.graph.load_ntriples(&ntriples) {
             Ok(c) => c,
-            Err(e) => return format!(r#"{{"error":"Failed to load triples: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("Failed to load triples: {}", e)),
         };
 
         // 2. SHACL (optional)
@@ -2111,7 +2109,7 @@ impl OpenOntologiesServer {
             } else {
                 match std::fs::read_to_string(shapes_input) {
                     Ok(c) => c,
-                    Err(e) => return format!(r#"{{"error":"Cannot read shapes: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Cannot read shapes: {}", e)),
                 }
             };
             match ShaclValidator::validate(&self.graph, &shapes) {
@@ -2130,7 +2128,7 @@ impl OpenOntologiesServer {
                         shacl_result = parsed;
                     }
                 }
-                Err(e) => return format!(r#"{{"error":"SHACL validation failed: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("SHACL validation failed: {}", e)),
             }
         }
 
@@ -2143,7 +2141,7 @@ impl OpenOntologiesServer {
                         reason_result = parsed;
                     }
                 }
-                Err(e) => return format!(r#"{{"error":"Reasoning failed: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("Reasoning failed: {}", e)),
             }
         }
 
@@ -2169,7 +2167,7 @@ impl OpenOntologiesServer {
         // is identical.
         let driver = match sqlsource::detect_driver(&input.connection) {
             Ok(d) => d,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
 
         let tables: Vec<crate::schema::TableInfo> = match driver {
@@ -2178,7 +2176,7 @@ impl OpenOntologiesServer {
                 {
                     match SchemaIntrospector::introspect_postgres(&input.connection).await {
                         Ok(t) => t,
-                        Err(e) => return format!(r#"{{"error":"Postgres connection failed: {}"}}"#, e),
+                        Err(e) => return Self::err_json(format!("Postgres connection failed: {}", e)),
                     }
                 }
                 #[cfg(not(feature = "postgres"))]
@@ -2197,8 +2195,8 @@ impl OpenOntologiesServer {
                     .await
                     {
                         Ok(Ok(t)) => t,
-                        Ok(Err(e)) => return format!(r#"{{"error":"DuckDB introspection failed: {}"}}"#, e),
-                        Err(e) => return format!(r#"{{"error":"DuckDB worker panicked: {}"}}"#, e),
+                        Ok(Err(e)) => return Self::err_json(format!("DuckDB introspection failed: {}", e)),
+                        Err(e) => return Self::err_json(format!("DuckDB worker panicked: {}", e)),
                     }
                 }
                 #[cfg(not(feature = "duckdb"))]
@@ -2212,7 +2210,7 @@ impl OpenOntologiesServer {
 
         // Validate + load
         if let Err(e) = GraphStore::validate_turtle(&turtle) {
-            return format!(r#"{{"error":"Generated Turtle invalid: {}"}}"#, e);
+            return Self::err_json(format!("Generated Turtle invalid: {}", e));
         }
 
         match self.graph.load_turtle(&turtle, Some(base_iri)) {
@@ -2224,7 +2222,7 @@ impl OpenOntologiesServer {
                 "triples": count,
                 "base_iri": base_iri,
             }).to_string(),
-            Err(e) => format!(r#"{{"error":"Failed to load: {}"}}"#, e),
+            Err(e) => Self::err_json(format!("Failed to load: {}", e)),
         }
     }
 
@@ -2239,12 +2237,12 @@ impl OpenOntologiesServer {
         // Validate connection scheme up front so we fail fast with a clear error.
         let driver = match sqlsource::detect_driver(&input.connection) {
             Ok(d) => d,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
 
         let rows = match sqlsource::query_rows(&input.connection, &input.sql).await {
             Ok(r) => r,
-            Err(e) => return format!(r#"{{"error":"SQL query failed: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("SQL query failed: {}", e)),
         };
 
         if rows.is_empty() {
@@ -2263,15 +2261,15 @@ impl OpenOntologiesServer {
             if input.inline_mapping.unwrap_or(false) {
                 match serde_json::from_str::<MappingConfig>(mapping_str) {
                     Ok(m) => m,
-                    Err(e) => return format!(r#"{{"error":"Invalid mapping JSON: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Invalid mapping JSON: {}", e)),
                 }
             } else {
                 match std::fs::read_to_string(mapping_str) {
                     Ok(content) => match serde_json::from_str::<MappingConfig>(&content) {
                         Ok(m) => m,
-                        Err(e) => return format!(r#"{{"error":"Invalid mapping file: {}"}}"#, e),
+                        Err(e) => return Self::err_json(format!("Invalid mapping file: {}", e)),
                     },
-                    Err(e) => return format!(r#"{{"error":"Cannot read mapping file: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("Cannot read mapping file: {}", e)),
                 }
             }
         } else {
@@ -2283,7 +2281,7 @@ impl OpenOntologiesServer {
         let load_result = self.graph.load_ntriples(&ntriples);
         let count = match load_result {
             Ok(c) => c,
-            Err(e) => return format!(r#"{{"error":"Failed to load triples: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("Failed to load triples: {}", e)),
         };
 
         // CDC: record new watermark if caller asked us to track one.
@@ -2330,9 +2328,9 @@ impl OpenOntologiesServer {
     async fn onto_sql_sync_state(&self, Parameters(input): Parameters<OntoSqlSyncStateInput>) -> String {
         match crate::sql_sync::get_state(&self.db, &input.sync_key) {
             Ok(Some(state)) => serde_json::to_string(&state)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
             Ok(None) => "null".to_string(),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2340,7 +2338,7 @@ impl OpenOntologiesServer {
     async fn onto_sql_sync_reset(&self, Parameters(input): Parameters<OntoSqlSyncResetInput>) -> String {
         match crate::sql_sync::reset_watermark(&self.db, &input.sync_key) {
             Ok(removed) => format!(r#"{{"removed":{}}}"#, removed),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2348,8 +2346,8 @@ impl OpenOntologiesServer {
     async fn onto_sql_sync_states_list(&self) -> String {
         match crate::sql_sync::list_states(&self.db) {
             Ok(states) => serde_json::to_string(&states)
-                .unwrap_or_else(|e| format!(r#"{{"error":"serialization: {}"}}"#, e)),
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+                .unwrap_or_else(|e| Self::err_json(format!("serialization: {}", e))),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2361,7 +2359,7 @@ impl OpenOntologiesServer {
         let source = if std::path::Path::new(&input.source).exists() {
             match std::fs::read_to_string(&input.source) {
                 Ok(s) => s,
-                Err(e) => return format!(r#"{{"error":"Failed to read source: {}"}}"#, e),
+                Err(e) => return Self::err_json(format!("Failed to read source: {}", e)),
             }
         } else {
             input.source
@@ -2373,7 +2371,7 @@ impl OpenOntologiesServer {
                 if std::path::Path::new(&t).exists() {
                     match std::fs::read_to_string(&t) {
                         Ok(s) => Some(s),
-                        Err(e) => return format!(r#"{{"error":"Failed to read target: {}"}}"#, e),
+                        Err(e) => return Self::err_json(format!("Failed to read target: {}", e)),
                     }
                 } else {
                     Some(t)
@@ -2399,7 +2397,7 @@ impl OpenOntologiesServer {
                 );
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2411,7 +2409,7 @@ impl OpenOntologiesServer {
                 self.lineage().record(&self.session_id, "AF", "align_feedback", if input.accepted { "accepted" } else { "rejected" });
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2422,7 +2420,7 @@ impl OpenOntologiesServer {
                 self.lineage().record(&self.session_id, "LF", "lint_feedback", if input.accepted { "accepted" } else { "dismissed" });
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2433,7 +2431,7 @@ impl OpenOntologiesServer {
                 self.lineage().record(&self.session_id, "EF", "enforce_feedback", if input.accepted { "accepted" } else { "dismissed" });
                 result
             }
-            Err(e) => format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => Self::err_json(e),
         }
     }
 
@@ -2463,12 +2461,12 @@ impl OpenOntologiesServer {
         // so read the union of all graphs, not the default graph alone.
         let result = match self.graph.sparql_select_union(classes_query) {
             Ok(r) => r,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
 
         let parsed: serde_json::Value = match serde_json::from_str(&result) {
             Ok(v) => v,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
 
         let mut class_labels: std::collections::HashMap<String, String> = std::collections::HashMap::new();
@@ -2491,7 +2489,7 @@ impl OpenOntologiesServer {
         let trainer = crate::structembed::StructuralTrainer::new(struct_dim, struct_epochs, 0.01);
         let struct_embeddings = match trainer.train(&self.graph) {
             Ok(e) => e,
-            Err(e) => return format!(r#"{{"error":"structural training failed: {}"}}"#, e),
+            Err(e) => return Self::err_json(format!("structural training failed: {}", e)),
         };
 
         let mut embedded_count = 0;
@@ -2532,7 +2530,7 @@ impl OpenOntologiesServer {
         {
             let vecstore = self.vecstore.lock().unwrap();
             if let Err(e) = vecstore.persist() {
-                return format!(r#"{{"error":"failed to persist embeddings: {}"}}"#, e);
+                return Self::err_json(format!("failed to persist embeddings: {}", e));
             }
         }
 
@@ -2565,7 +2563,7 @@ impl OpenOntologiesServer {
             let persisted = if persist {
                 match vecstore.persist_cosine_index() {
                     Ok(()) => true,
-                    Err(e) => return format!(r#"{{"error":"persist failed: {}"}}"#, e),
+                    Err(e) => return Self::err_json(format!("persist failed: {}", e)),
                 }
             } else {
                 false
@@ -2599,7 +2597,7 @@ impl OpenOntologiesServer {
 
         let query_vec = match embedder.embed(&input.query).await {
             Ok(v) => v,
-            Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+            Err(e) => return Self::err_json(e),
         };
 
         let mut vecstore = self.vecstore.lock().unwrap();
@@ -2681,8 +2679,8 @@ impl OpenOntologiesServer {
         let struct_b = vecstore.get_struct_vec(&input.iri_b);
 
         if text_a.is_none() || text_b.is_none() {
-            return format!(r#"{{"error":"IRI not found in embeddings. Run onto_embed first. Missing: {}"}}"#,
-                if text_a.is_none() { &input.iri_a } else { &input.iri_b });
+            return Self::err_json(format!("IRI not found in embeddings. Run onto_embed first. Missing: {}",
+                if text_a.is_none() { &input.iri_a } else { &input.iri_b }));
         }
 
         let cos = crate::poincare::cosine_similarity(&text_a.unwrap(), &text_b.unwrap());

--- a/tests/serialisation_invariance_test.rs
+++ b/tests/serialisation_invariance_test.rs
@@ -398,3 +398,39 @@ fn plan_blast_radius_reads_dependents_from_every_graph() {
     assert!(ta >= 1, "turtle side must count Building's dependents, or this proves nothing: {t}");
     assert_eq!(ta, q["blast_radius"]["triples_affected"].as_u64().unwrap(), "turtle {t}\ntrig {q}");
 }
+
+#[test]
+fn incremental_reasoner_reads_schema_from_every_graph() {
+    // onto_reason_incremental reads the TBox to know the rules, then derives the
+    // consequences of a delta. Reading the default graph alone, it saw no schema
+    // for a TriG/N-Quads store and derived nothing while reporting success.
+    use open_ontologies::reason_incremental::IncrementalReasoner;
+    let rdf_type = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>".to_string();
+    // Delta: a new individual typed ex:Dog. Schema ex:Dog rdfs:subClassOf ex:Animal
+    // must yield the inferred type ex:Animal.
+    let delta = vec![(
+        "<http://example.org/rex>".to_string(),
+        rdf_type,
+        "<http://example.org/Dog>".to_string(),
+    )];
+    let schema = "ex:Dog rdfs:subClassOf ex:Animal .";
+    let prefixes = "@prefix ex: <http://example.org/> . \
+                    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .";
+
+    let turtle = Arc::new(GraphStore::new());
+    turtle.load_turtle(&format!("{prefixes} {schema}"), None).unwrap();
+    let trig = Arc::new(GraphStore::new());
+    trig.load_content(&format!("{prefixes} ex:g {{ {schema} }}"), RdfFormat::TriG).unwrap();
+
+    let t: serde_json::Value = serde_json::from_str(
+        &IncrementalReasoner::run(&turtle, &delta, false).unwrap(),
+    ).unwrap();
+    let q: serde_json::Value = serde_json::from_str(
+        &IncrementalReasoner::run(&trig, &delta, false).unwrap(),
+    ).unwrap();
+    assert_eq!(
+        t["inferred_count"].as_u64(), Some(1),
+        "turtle side must derive rex a Animal, or this proves nothing: {t}"
+    );
+    assert_eq!(t["inferred_count"], q["inferred_count"], "turtle {t}\ntrig {q}");
+}


### PR DESCRIPTION
Two follow-ups flagged in #129.

## Incremental reasoner was graph-blind on schema (`src/reason_incremental.rs`)
`Schema::read` and the neighbour/type scans read the default graph alone, so a store whose schema or instances sit in named graphs (a TriG/N-Quads load, a per-version schema graph) derived nothing while the run reported success. These are codebase-authored questions about the whole store, so they now read the union of all graphs, consistent with the project's graph-scope doctrine (schema is scope-free) and with the six tools fixed in #129.

Design note: only the **reads** widen. Derived triples still materialise where they did before (default graph, matching base `onto_reason`); changing the write target is a separate materialization decision and out of scope here.

Pinned by `incremental_reasoner_reads_schema_from_every_graph` (Turtle vs TriG, asserts the Turtle side derived something first).

## MCP tool JSON was hand-built and unescaped (`src/server.rs`)
Every `{"error": ...}` reply (and the success objects that interpolate strings) was assembled with `format!` and a raw string, so a quote, backslash, or newline in an input-derived value (a URL, a parse error echoing content) produced malformed JSON the client cannot parse. The `.replace('"', "'")` calls were an incomplete escaping hack.

Added a small `err_json` helper and routed all **183 error sites** plus **8 string-interpolating success sites** through `serde_json`, which escapes correctly. Sites interpolating only integers/bools are unchanged. No tool names, descriptions, or behavior changed.

Verified: `cargo build --all-features`, `cargo test --all-features`, and `cargo clippy --all-features --all-targets` all pass with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)